### PR TITLE
feat: terraform module

### DIFF
--- a/terraform/bigquery.tf
+++ b/terraform/bigquery.tf
@@ -1,0 +1,32 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_bigquery_dataset" "sink" {
+  project    = data.google_project.default.project_id
+  dataset_id = var.dataset_id
+  location   = var.dataset_location
+
+  depends_on = [
+    google_project_service.default["bigquery.googleapis.com"]
+  ]
+}
+
+resource "google_bigquery_dataset_iam_binding" "bindings" {
+  for_each = var.dataset_iam
+
+  project    = data.google_project.default.project_id
+  dataset_id = google_bigquery_dataset.sink.dataset_id
+  role       = each.key
+  members    = each.value
+}

--- a/terraform/logsink.tf
+++ b/terraform/logsink.tf
@@ -1,0 +1,40 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_logging_project_sink" "bigquery_sink" {
+  name        = format("%s-%s", var.log_sink_name, var.dataset_id)
+  project     = var.project_id
+  destination = "bigquery.googleapis.com/projects/${var.project_id}/datasets/${var.dataset_id}"
+
+  filter = <<-EOT
+    LOG_ID("audit.abcxyz/activity") AND
+    labels.service="github-token-minter"
+  EOT
+
+  unique_writer_identity = true
+  bigquery_options {
+    use_partitioned_tables = true
+  }
+
+  depends_on = [
+    google_project_service.default["logging.googleapis.com"],
+  ]
+}
+
+resource "google_bigquery_dataset_iam_member" "bigquery_sink_memeber" {
+  dataset_id = google_bigquery_dataset.sink.dataset_id
+  project    = var.project_id
+  role       = "roles/bigquery.dataEditor"
+  member     = google_logging_project_sink.bigquery_sink.writer_identity
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -1,0 +1,59 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+data "google_project" "default" {
+  project_id = var.project_id
+}
+
+resource "google_project_service" "default" {
+  project = var.project_id
+  for_each = toset([
+    "cloudresourcemanager.googleapis.com",
+    "bigquery.googleapis.com",
+    "logging.googleapis.com",
+  ])
+  service            = each.value
+  disable_on_destroy = false
+}
+
+resource "google_service_account" "run_service_account" {
+  project      = data.google_project.default.project_id
+  account_id   = "${var.name}-sa"
+  display_name = "${var.name}-sa Cloud Run Service Account"
+}
+
+module "cloud_run" {
+  source                = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=main"
+  project_id            = data.google_project.default.project_id
+  name                  = var.name
+  image                 = var.image
+  ingress               = "internal-and-cloud-load-balancing"
+  secrets               = ["github-application-id", "github-installation-id", "github-privatekey"]
+  service_account_email = google_service_account.run_service_account.email
+  service_iam           = var.service_iam
+  secret_envvars = {
+    "GITHUB_APP_ID" : {
+      name : "github-application-id",
+      version : "latest",
+    },
+    "GITHUB_INSTALL_ID" : {
+      name : "github-installation-id",
+      version : "latest",
+    },
+    "GITHUB_PRIVATE_KEY" : {
+      name : "github-privatekey",
+      version : "latest",
+    }
+  }
+}

--- a/terraform/outputs.tf
+++ b/terraform/outputs.tf
@@ -1,0 +1,48 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+output "run_service_url" {
+  description = "The Cloud Run service url."
+  value       = module.cloud_run.url
+}
+
+output "run_service_id" {
+  description = "The Cloud Run service id."
+  value       = module.cloud_run.service_id
+}
+
+output "run_service_name" {
+  description = "The Cloud Run service name."
+  value       = module.cloud_run.service_name
+}
+
+output "run_service_account_email" {
+  description = "Cloud Run service account email."
+  value       = google_service_account.run_service_account.email
+}
+
+output "run_service_account_member" {
+  description = "Cloud Run service account email iam string."
+  value       = google_service_account.run_service_account.member
+}
+
+output "bigquery_dataset_id" {
+  description = "BigQuery dataset resource."
+  value       = google_bigquery_dataset.sink.dataset_id
+}
+
+output "bigquery_logsink_id" {
+  description = "BigQuery log sink identifier."
+  value       = google_logging_project_sink.bigquery_sink.id
+}

--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -1,0 +1,22 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+terraform {
+  required_version = ">= 1.0.0"
+  required_providers {
+    google = {
+      version = ">= 4.45"
+    }
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -1,0 +1,63 @@
+# Copyright 2023 The Authors (see AUTHORS file)
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project_id" {
+  description = "The GCP project ID."
+  type        = string
+}
+
+variable "name" {
+  description = "The name of this component."
+  type        = string
+  default     = "github-token-minter"
+  validation {
+    condition     = can(regex("^[A-Za-z][0-9A-Za-z-]+[0-9A-Za-z]$", var.name))
+    error_message = "Name can only contain letters, numbers, hyphens(-) and must start with letter."
+  }
+}
+
+variable "image" {
+  description = "Cloud Run service image name to deploy."
+  type        = string
+  default     = "gcr.io/cloudrun/hello:latest"
+}
+
+variable "service_iam" {
+  description = "IAM bindings in {ROLE => [MEMBERS]} format for the Cloud Run service."
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "dataset_location" {
+  type        = string
+  description = "The BigQuery dataset location."
+  default     = "US"
+}
+
+variable "dataset_id" {
+  type        = string
+  description = "The BigQuery dataset id to create."
+}
+
+variable "dataset_iam" {
+  description = "IAM bindings in {ROLE => [MEMBERS]} format for the BigQuery dataset."
+  type        = map(list(string))
+  default     = {}
+}
+
+variable "log_sink_name" {
+  type        = string
+  default     = "github-token-minter-logs"
+  description = "The log sink name that filters for audit logs."
+}


### PR DESCRIPTION
Terraform module for deploying github-token-minter to cloud run with a log sink to BigQuery for audit data.