### PR TITLE
fix: handle 'created' response with invalid json returned by GitHub

### DIFF
--- a/.github/actions/mint-token/action.yml
+++ b/.github/actions/mint-token/action.yml
@@ -54,8 +54,14 @@ runs:
                   }
               });
               if (response.ok) {
-                const resp = await response.json();
-                core.setOutput('token', resp.token);
+                try {
+                  const resp = await response.json();
+                  core.setOutput('token', resp.token);
+                } catch (err) {
+                  // Handle an invalid JSON response and log the response body
+                  const respBody = await response.text();
+                  throw new Error(`Invalid JSON Response: ${respBody}`);
+                }
               } else {
                 const errorBody = await response.text();
                 core.error(`Error response from server ${errorBody}`)

--- a/pkg/server/token_minter.go
+++ b/pkg/server/token_minter.go
@@ -382,7 +382,7 @@ func (s *TokenMintServer) generateInstallationAccessToken(ctx context.Context, g
 	// e.g. 'issues':'write' for an empty repository list. This 201 comes with a response that is not actually JSON.
 	// Attempt to parse the JSON to see if this is a valid token, if it is not then respond with an error and log the
 	// actual response from GitHub.
-	tokenContent := map[string]string{}
+	tokenContent := map[string]interface{}{}
 	if err := json.Unmarshal(b, &tokenContent); err != nil {
 		logger.Errorf("invalid access token from GitHub - Body: %s", string(b))
 		return "", fmt.Errorf("invalid access token response from GitHub")

--- a/pkg/server/token_minter.go
+++ b/pkg/server/token_minter.go
@@ -382,7 +382,7 @@ func (s *TokenMintServer) generateInstallationAccessToken(ctx context.Context, g
 	// e.g. 'issues':'write' for an empty repository list. This 201 comes with a response that is not actually JSON.
 	// Attempt to parse the JSON to see if this is a valid token, if it is not then respond with an error and log the
 	// actual response from GitHub.
-	tokenContent := map[string]interface{}{}
+	tokenContent := map[string]any{}
 	if err := json.Unmarshal(b, &tokenContent); err != nil {
 		logger.Errorf("invalid access token from GitHub - Body: %s", string(b))
 		return "", fmt.Errorf("invalid access token response from GitHub")

--- a/pkg/server/token_minter_test.go
+++ b/pkg/server/token_minter_test.go
@@ -56,7 +56,7 @@ func TestTokenMintServer_ProcessRequest(t *testing.T) {
 
 	fakeGitHub := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(201)
-		fmt.Fprintf(w, `this-is-the-token-from-github`)
+		fmt.Fprintf(w, `{"token":"this-is-the-token-from-github"}`)
 	}))
 
 	cases := []struct {


### PR DESCRIPTION
Fixes #42 