### PR TITLE
chore: change target subdirectory defaults of abc-templates 

### DIFF
--- a/abc.templates/deployments/spec.yaml
+++ b/abc.templates/deployments/spec.yaml
@@ -20,7 +20,7 @@ desc: 'Generate the components necessary to deploy GitHub Token Minter'
 inputs:
   - name: 'subdirectory'
     desc: 'The subdirectory to render the template'
-    default: 'deployments/github-token-minter'
+    default: 'github-token-minter/deployments'
   - name: 'wif_provider'
     desc: 'The Google Cloud workload identity federation provider for GitHub Token Minter'
   - name: 'wif_service_account'

--- a/abc.templates/infra/spec.yaml
+++ b/abc.templates/infra/spec.yaml
@@ -20,7 +20,7 @@ desc: 'Generate the infrastructure necessary to run GitHub Token Minter'
 inputs:
   - name: 'subdirectory'
     desc: 'The subdirectory to render the template'
-    default: 'infra/github-token-minter'
+    default: 'github-token-minter/infra'
   - name: 'project_id'
     desc: 'The Google Cloud project ID to deploy GitHub Token Minter'
     rules:


### PR DESCRIPTION
Previously rendered output,
```
deployments/
  github-token-minter/
infra/
  github-token-minter/
```

Proposed rendered output,
```
github-token-minter/
   deployments/
   infra/
```
