### PR TITLE
chore: use custom name to customize cloud run resource names and log sink name

### DIFF
--- a/abc.templates/infra/contents/main.tf
+++ b/abc.templates/infra/contents/main.tf
@@ -11,6 +11,7 @@ module "REPLACE_MODULE_NAME" {
   name       = "REPLACE_CUSTOM_NAME"
   domains    = ["REPLACE_DOMAIN"]
   dataset_id = "REPLACE_MODULE_NAME_audit_prod"
+  log_sink_name = "REPLACE_CUSTOM_NAME-logs"
 
   github_owner_id           = "REPLACE_GITHUB_OWNER_ID"
   ci_service_account_member = local.automation_service_account_member

--- a/abc.templates/infra/contents/main.tf
+++ b/abc.templates/infra/contents/main.tf
@@ -8,6 +8,7 @@ module "REPLACE_MODULE_NAME" {
 
   project_id = local.project_id
 
+  name       = "REPLACE_CUSTOM_NAME"
   domains    = ["REPLACE_DOMAIN"]
   dataset_id = "REPLACE_MODULE_NAME_audit_prod"
 

--- a/abc.templates/infra/spec.yaml
+++ b/abc.templates/infra/spec.yaml
@@ -21,6 +21,11 @@ inputs:
   - name: 'custom_name'
     desc: 'A custom name for Github Token Minter'
     default: 'github-token-minter'
+    rules:
+      - rule: 'size(custom_name) <= int(19)'
+        message: 'The custom_name must be at most 19 characters.'
+      - rule: 'matches(custom_name, "^[A-Za-z][0-9A-Za-z-]+[0-9A-Za-z]$")'
+        message: 'Name can only contain letters, numbers, hyphens(-) and must start with letter.'
   - name: 'subdirectory'
     desc: 'The subdirectory to render the template and the bucket prefix for storing terraform state of GitHub Token Minter'
     default: 'github-token-minter/infra'

--- a/abc.templates/infra/spec.yaml
+++ b/abc.templates/infra/spec.yaml
@@ -49,6 +49,8 @@ steps:
     params:
       paths: ['{{.subdirectory}}']
       replacements:
+        - to_replace: 'REPLACE_CUSTOM_NAME'
+          with: '{{.custom_name}}'
         - to_replace: 'REPLACE_MODULE_NAME'
           with: '{{toLowerSnakeCase .custom_name}}'
         - to_replace: 'REPLACE_PROJECT_ID'


### PR DESCRIPTION
Uses `custom_name` to override the default values of cloud run and log sink resource names. This also adds validation rules on the `custom_name` input variable.