### PR TITLE
feat: add configuration validation command

### DIFF
--- a/pkg/cli/mintycfg.go
+++ b/pkg/cli/mintycfg.go
@@ -1,0 +1,79 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cli
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/abcxyz/github-token-minter/pkg/mintycfg"
+	"github.com/abcxyz/github-token-minter/pkg/version"
+	"github.com/abcxyz/pkg/cli"
+	"github.com/abcxyz/pkg/logging"
+)
+
+var _ cli.Command = (*MintyCfgCommand)(nil)
+
+type MintyCfgCommand struct {
+	cli.BaseCommand
+	cfg *mintycfg.Config
+
+	// testFlagSetOpts is only used for testing.
+	testFlagSetOpts []cli.Option
+}
+
+func (c *MintyCfgCommand) Desc() string {
+	return ``
+}
+
+func (c *MintyCfgCommand) Help() string {
+	return `
+Usage: {{ COMMAND }} [options]
+       Execute the minty configuration validator 
+`
+}
+
+func (c *MintyCfgCommand) Flags() *cli.FlagSet {
+	c.cfg = &mintycfg.Config{}
+	set := cli.NewFlagSet(c.testFlagSetOpts...)
+	return c.cfg.ToFlags(set)
+}
+
+func (c *MintyCfgCommand) Run(ctx context.Context, args []string) error {
+	f := c.Flags()
+	if err := f.Parse(args); err != nil {
+		return fmt.Errorf("failed to parse flags: %w", err)
+	}
+	args = f.Args()
+	if len(args) > 0 {
+		return fmt.Errorf("unexpected arguments: %q", args)
+	}
+
+	logger := logging.FromContext(ctx)
+	logger.DebugContext(ctx, "running job",
+		"name", version.Name,
+		"commit", version.Commit,
+		"version", version.Version)
+
+	if err := c.cfg.Validate(); err != nil {
+		return fmt.Errorf("invalid configuration: %w", err)
+	}
+	logger.DebugContext(ctx, "loaded configuration", "config", c.cfg)
+
+	if err := mintycfg.Run(ctx, c.cfg); err != nil {
+		return fmt.Errorf("error executing validation: %w", err)
+	}
+	return nil
+}

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -38,6 +38,17 @@ var rootCmd = func() cli.Command {
 					},
 				}
 			},
+			"config": func() cli.Command {
+				return &cli.RootCommand{
+					Name:        "config",
+					Description: "Configuration operations",
+					Commands: map[string]cli.CommandFactory{
+						"validate": func() cli.Command {
+							return &MintyCfgCommand{}
+						},
+					},
+				}
+			},
 		},
 	}
 }

--- a/pkg/config/config_evaluator.go
+++ b/pkg/config/config_evaluator.go
@@ -37,7 +37,7 @@ type ConfigEvaluator interface {
 }
 
 type configEvaluator struct {
-	loaders []configFileLoader
+	loaders []ConfigFileLoader
 }
 
 func NewConfigEvaluator(expireAt time.Duration, localConfigDir, repoConfigPath, orgConfigPath, ref string, app *githubauth.App) (*configEvaluator, error) {
@@ -48,15 +48,15 @@ func NewConfigEvaluator(expireAt time.Duration, localConfigDir, repoConfigPath, 
 	}
 	// create and configure all of the file loaders
 	localLoader := newCachingConfigLoader(expireAt,
-		newCompilingConfigLoader(env, &localConfigFileLoader{configDir: localConfigDir}))
+		NewCompilingConfigLoader(env, &localConfigFileLoader{configDir: localConfigDir}))
 	inRepoLoader := newCachingConfigLoader(expireAt,
-		newCompilingConfigLoader(env, &ghInRepoConfigFileLoader{
+		NewCompilingConfigLoader(env, &ghInRepoConfigFileLoader{
 			provider:   makeGitHubClientProvider(app),
 			configPath: ".github/minty.yaml",
 			ref:        "main",
 		}))
 	orgLoader := newCachingConfigLoader(expireAt,
-		newCompilingConfigLoader(env, &fixedRepoConfigFileLoader{
+		NewCompilingConfigLoader(env, &fixedRepoConfigFileLoader{
 			repo: ".google-github",
 			loader: &ghInRepoConfigFileLoader{
 				provider:   makeGitHubClientProvider(app),
@@ -65,7 +65,7 @@ func NewConfigEvaluator(expireAt time.Duration, localConfigDir, repoConfigPath, 
 			},
 		}))
 	return &configEvaluator{
-		loaders: []configFileLoader{
+		loaders: []ConfigFileLoader{
 			localLoader,
 			inRepoLoader,
 			orgLoader,
@@ -75,7 +75,7 @@ func NewConfigEvaluator(expireAt time.Duration, localConfigDir, repoConfigPath, 
 
 func (l *configEvaluator) Eval(ctx context.Context, org, repo, scope string, token interface{}) (*Scope, error) {
 	for _, loader := range l.loaders {
-		contents, err := loader.load(ctx, org, repo)
+		contents, err := loader.Load(ctx, org, repo)
 		if err != nil {
 			return nil, fmt.Errorf("error reading configuration, child reader threw error: %w", err)
 		}

--- a/pkg/config/config_evaluator_test.go
+++ b/pkg/config/config_evaluator_test.go
@@ -30,7 +30,7 @@ type testConfigFileLoader struct {
 	err    error
 }
 
-func (l *testConfigFileLoader) load(ctx context.Context, org, repo string) (*Config, error) {
+func (l *testConfigFileLoader) Load(ctx context.Context, org, repo string) (*Config, error) {
 	return l.result, l.err
 }
 
@@ -55,7 +55,7 @@ func TestOrderedConfigFileLoader(t *testing.T) {
 		{
 			name: "single child with result",
 			reader: &configEvaluator{
-				loaders: []configFileLoader{
+				loaders: []ConfigFileLoader{
 					&compilingConfigLoader{
 						env: env, loader: &testConfigFileLoader{
 							result: &Config{
@@ -81,7 +81,7 @@ func TestOrderedConfigFileLoader(t *testing.T) {
 		{
 			name: "single child with error",
 			reader: &configEvaluator{
-				loaders: []configFileLoader{
+				loaders: []ConfigFileLoader{
 					&compilingConfigLoader{
 						env: env, loader: &testConfigFileLoader{
 							result: nil,
@@ -101,7 +101,7 @@ func TestOrderedConfigFileLoader(t *testing.T) {
 		{
 			name: "multiple children with result in first",
 			reader: &configEvaluator{
-				loaders: []configFileLoader{
+				loaders: []ConfigFileLoader{
 					&compilingConfigLoader{
 						env: env, loader: &testConfigFileLoader{
 							result: &Config{Scopes: map[string]*Scope{
@@ -135,7 +135,7 @@ func TestOrderedConfigFileLoader(t *testing.T) {
 		{
 			name: "multiple children with error in first",
 			reader: &configEvaluator{
-				loaders: []configFileLoader{
+				loaders: []ConfigFileLoader{
 					&compilingConfigLoader{
 						env: env, loader: &testConfigFileLoader{
 							result: nil,
@@ -161,7 +161,7 @@ func TestOrderedConfigFileLoader(t *testing.T) {
 		{
 			name: "multiple children with result in second",
 			reader: &configEvaluator{
-				loaders: []configFileLoader{
+				loaders: []ConfigFileLoader{
 					&compilingConfigLoader{
 						env: env, loader: &testConfigFileLoader{
 							result: nil,
@@ -193,7 +193,7 @@ func TestOrderedConfigFileLoader(t *testing.T) {
 		{
 			name: "multiple children with error in second",
 			reader: &configEvaluator{
-				loaders: []configFileLoader{
+				loaders: []ConfigFileLoader{
 					&compilingConfigLoader{
 						env: env, loader: &testConfigFileLoader{
 							result: nil,
@@ -219,7 +219,7 @@ func TestOrderedConfigFileLoader(t *testing.T) {
 		{
 			name: "multiple children with no results",
 			reader: &configEvaluator{
-				loaders: []configFileLoader{
+				loaders: []ConfigFileLoader{
 					&compilingConfigLoader{
 						env: env, loader: &testConfigFileLoader{
 							result: nil,
@@ -245,7 +245,7 @@ func TestOrderedConfigFileLoader(t *testing.T) {
 		{
 			name: "v1 config match first",
 			reader: &configEvaluator{
-				loaders: []configFileLoader{
+				loaders: []ConfigFileLoader{
 					&compilingConfigLoader{
 						env: env, loader: &testConfigFileLoader{
 							result: &Config{
@@ -275,7 +275,7 @@ func TestOrderedConfigFileLoader(t *testing.T) {
 		{
 			name: "v1 config match second",
 			reader: &configEvaluator{
-				loaders: []configFileLoader{
+				loaders: []ConfigFileLoader{
 					&compilingConfigLoader{
 						env: env, loader: &testConfigFileLoader{
 							result: &Config{
@@ -305,7 +305,7 @@ func TestOrderedConfigFileLoader(t *testing.T) {
 		{
 			name: "v1 config match none",
 			reader: &configEvaluator{
-				loaders: []configFileLoader{
+				loaders: []ConfigFileLoader{
 					&compilingConfigLoader{
 						env: env, loader: &testConfigFileLoader{
 							result: &Config{

--- a/pkg/config/config_loader_test.go
+++ b/pkg/config/config_loader_test.go
@@ -180,7 +180,7 @@ rule:
 				},
 			}
 
-			got, err := loader.load(ctx, tc.org, tc.repo)
+			got, err := loader.Load(ctx, tc.org, tc.repo)
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("mismatch (-want, +got):\n%s", diff)
 			}
@@ -279,7 +279,7 @@ scope:
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := read([]byte(tc.contents))
+			got, err := Read([]byte(tc.contents))
 			if diff := cmp.Diff(tc.want, got); diff != "" {
 				t.Errorf("mismatch (-want, +got):\n%s", diff)
 			}

--- a/pkg/mintycfg/config.go
+++ b/pkg/mintycfg/config.go
@@ -1,0 +1,82 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mintycfg
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/sethvargo/go-envconfig"
+
+	"github.com/abcxyz/pkg/cfgloader"
+	"github.com/abcxyz/pkg/cli"
+)
+
+// Config defines the set of environment variables required
+// for running the artifact job.
+type Config struct {
+	MintyFile string `env:"MINTY_FILE,required"`
+	Scope     string `env:"SCOPE,required"`
+	Token     string `env:"TOKEN,required"`
+}
+
+// Validate validates the artifacts config after load.
+func (cfg *Config) Validate() error {
+	if cfg.MintyFile == "" {
+		return fmt.Errorf("MINTY_FILE is required")
+	}
+	return nil
+}
+
+// NewConfig creates a new Config from environment variables.
+func NewConfig(ctx context.Context) (*Config, error) {
+	return newConfig(ctx, envconfig.OsLookuper())
+}
+
+func newConfig(ctx context.Context, lu envconfig.Lookuper) (*Config, error) {
+	var cfg Config
+	if err := cfgloader.Load(ctx, &cfg, cfgloader.WithLookuper(lu)); err != nil {
+		return nil, fmt.Errorf("failed to parse minty validation config: %w", err)
+	}
+	return &cfg, nil
+}
+
+// ToFlags binds the config to the [cli.FlagSet] and returns it.
+func (cfg *Config) ToFlags(set *cli.FlagSet) *cli.FlagSet {
+	f := set.NewSection("COMMON JOB OPTIONS")
+
+	f.StringVar(&cli.StringVar{
+		Name:   "minty-file",
+		Target: &cfg.MintyFile,
+		EnvVar: "MINTY_FILE",
+		Usage:  `The minty config file to inspect.`,
+	})
+
+	f.StringVar(&cli.StringVar{
+		Name:   "scope",
+		Target: &cfg.Scope,
+		EnvVar: "SCOPE",
+		Usage:  `The scope to test.`,
+	})
+
+	f.StringVar(&cli.StringVar{
+		Name:   "token",
+		Target: &cfg.Token,
+		EnvVar: "token",
+		Usage:  `The token to test with.`,
+	})
+
+	return set
+}

--- a/pkg/mintycfg/runner.go
+++ b/pkg/mintycfg/runner.go
@@ -1,0 +1,99 @@
+// Copyright 2024 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// The mintycfg package contains a CLI command that can be used to validate minty
+// configuration files.
+package mintycfg
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/google/cel-go/cel"
+
+	"github.com/abcxyz/github-token-minter/pkg/config"
+)
+
+type singleFileConfigLoader struct {
+	filePath string
+}
+
+// Load reads the contents of configuration files from the local file system.
+func (l *singleFileConfigLoader) Load(ctx context.Context, org, repo string) (*config.Config, error) {
+	data, err := os.ReadFile(l.filePath)
+	if err != nil {
+		return nil, fmt.Errorf("error reading content from file: %w", err)
+	}
+	config, err := config.Read(data)
+	if err != nil {
+		return nil, fmt.Errorf("error converting raw config bytes into struct: %w", err)
+	}
+	return config, nil
+}
+
+func Run(ctx context.Context, cfg *Config) error {
+	// create an environment to compile any cel expressions
+	env, err := cel.NewEnv(cel.Variable("assertion", cel.DynType))
+	if err != nil {
+		return fmt.Errorf("failed to create CEL environment: %w", err)
+	}
+	// load the requested configuration file and attempte to compile all CEL expressions
+	loader := config.NewCompilingConfigLoader(env, &singleFileConfigLoader{filePath: cfg.MintyFile})
+	config, err := loader.Load(ctx, "", "")
+	if err != nil {
+		fmt.Printf("\nConfiguration failed to compile\n")
+		fmt.Printf("-- Error --\n%v\n", err)
+		return nil
+	}
+
+	// render the configuration information
+	fmt.Printf("\n#################\n\n")
+	fmt.Printf("\nConfiguration and all rules compiled successfully\n")
+	fmt.Printf("Config:\n")
+	fmt.Printf("- Version: %s\n", config.Version)
+	fmt.Printf("- Rule.If: %s\n", config.Rule.If)
+	fmt.Printf("- Scopes: \n")
+	for key, s := range config.Scopes {
+		fmt.Printf("  - %s:\n", key)
+		fmt.Printf("    - Rule.If: %s\n", s.Rule.If)
+		fmt.Printf("    - Repositories: %v\n", s.Repositories)
+		fmt.Printf("    - Permissions: %v\n", s.Permissions)
+	}
+	fmt.Printf("\n#################\n\n")
+
+	// if a scope and a token were provided, run evaluation against them to
+	// determine if there is a scope match and then output the scope contents
+	if cfg.Scope != "" && cfg.Token != "" {
+		var token map[string]string
+		if err := json.Unmarshal([]byte(cfg.Token), &token); err != nil {
+			return fmt.Errorf("error unmarshalling token content: %w", err)
+		}
+
+		scope, err := config.Eval(cfg.Scope, token)
+		if err != nil {
+			return fmt.Errorf("error evaluating scope: %q - %w", cfg.Scope, err)
+		}
+		fmt.Printf("Evaluated token against scope: %s\n", cfg.Scope)
+		fmt.Printf("Found scope: %v\n", cfg.Scope)
+		fmt.Printf("  - Permissions: %v\n", scope.Permissions)
+		fmt.Printf("  - Repositories: %v\n", scope.Repositories)
+		fmt.Printf("\n#################\n\n")
+	}
+
+	fmt.Println("Configuration parsed and loaded successfully")
+
+	return nil
+}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -62,7 +62,7 @@ func NewConfig(ctx context.Context) (*Config, error) {
 func newConfig(ctx context.Context, lu envconfig.Lookuper) (*Config, error) {
 	var cfg Config
 	if err := cfgloader.Load(ctx, &cfg, cfgloader.WithLookuper(lu)); err != nil {
-		return nil, fmt.Errorf("failed to parse retry server config: %w", err)
+		return nil, fmt.Errorf("failed to parse server config: %w", err)
 	}
 	return &cfg, nil
 }


### PR DESCRIPTION
Basic configuration file validation:

`go run cmd/minty/main.go config validate --minty-file=../secure-setup-terraform/.github/minty.yaml`

Will load the specified config file and compile all CEL expressions, it then outputs the configuration as it would be seen by minty like:

```
#################


Configuration and all rules compiled successfully
Config:
- Version: minty.abcxyz.dev/v2
- Rule.If: assertion.iss == 'https://token.actions.githubusercontent.com' &&
assertion.organization_id == '93787867' &&
assertion.repository_id == '560465650' &&
assertion.ref == 'refs/heads/main' 
- Scopes: 
  - draft-release:
    - Rule.If: assertion.workflow_ref == assertion.job_workflow_ref &&
assertion.workflow_ref.startsWith("abcxyz/secure-setup-terraform/.github/workflows/draft-release.yml") &&
assertion.event_name == 'workflow_dispatch'
    - Repositories: [secure-setup-terraform]
    - Permissions: map[contents:write pull_requests:write]
  - release:
    - Rule.If: assertion.workflow_ref == assertion.job_workflow_ref &&
assertion.workflow_ref.startsWith("abcxyz/secure-setup-terraform/.github/workflows/release.yml") &&
assertion.event_name == 'push'
    - Repositories: [secure-setup-terraform]
    - Permissions: map[contents:write]
  - update-checksums:
    - Rule.If: assertion.workflow_ref.startsWith("abcxyz/secure-setup-terraform/.github/workflows/update-checksums.yml") &&
(assertion.event_name == 'schedule' || assertion.event_name == 'workflow_dispatch') 
    - Repositories: [secure-setup-terraform]
    - Permissions: map[contents:write pull_requests:write]
  - create-release:
    - Rule.If: assertion.workflow_ref.startsWith("abcxyz/secure-setup-terraform/.github/workflows/create-release.yml") &&
assertion.event_name == 'push' 
    - Repositories: [secure-setup-terraform]
    - Permissions: map[contents:write]
Configuration parsed and loaded successfully

#################
```

Failed compilations tell you details about what expression didn't compile:

```
Configuration failed to compile
-- Error --
failed to compile CEL expressions in config: error compiling configuration ruleset: failed to compile ruleset: failed to compile CEL expression: ERROR: <input>:4:38: Syntax error: mismatched input '<EOF>' expecting {'[', '{', '(', '.', '-', '!', 'true', 'false', 'null', NUM_FLOAT, NUM_INT, NUM_UINT, STRING, BYTES, IDENTIFIER}
 | assertion.ref == 'refs/heads/main' &&
```

You can also provide a `scope` and a `token` and it will validate the token against the scope to see if it will provide a valid match:

```
go run cmd/minty/main.go config validate --minty-file=../secure-setup-terraform/.github/minty.yaml --scope=release --token='{"iss":"https://token.actions.githubusercontent.com","organization_id":"93787867","repository_id":"560465650","ref":"refs/heads/main","workflow_ref":"abcxyz/secure-setup-terraform/.github/workflows/release.yml","job_workflow_ref":"abcxyz/secure-setup-terraform/.github/workflows/release.yml","event_name":"push"}'
```

This outputs additional details along with the output from above;

```
#################

Evaluated token against scope: release
Found scope: release
  - Permissions: map[contents:write]
  - Repositories: [secure-setup-terraform]

#################
```