### PR TITLE
feat: additional diagnostics to make debugging easier in prod

### DIFF
--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -62,7 +62,7 @@ func (c *ServerCommand) Run(ctx context.Context, args []string) error {
 	}
 
 	logger := logging.FromContext(ctx)
-	logger.DebugContext(ctx, "running job",
+	logger.InfoContext(ctx, "running job",
 		"name", version.Name,
 		"commit", version.Commit,
 		"version", version.Version)
@@ -70,7 +70,7 @@ func (c *ServerCommand) Run(ctx context.Context, args []string) error {
 	if err := c.cfg.Validate(); err != nil {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
-	logger.DebugContext(ctx, "loaded configuration", "config", c.cfg)
+	logger.InfoContext(ctx, "loaded configuration", "config", c.cfg)
 
 	if err := server.Run(ctx, c.cfg); err != nil {
 		return fmt.Errorf("failed to start server: %w", err)

--- a/pkg/config/config_evaluator.go
+++ b/pkg/config/config_evaluator.go
@@ -36,6 +36,11 @@ const (
 type GitHubClientProvider func(ctx context.Context, org, repo string) (*github.Client, error)
 
 type ConfigEvaluator interface {
+	// Eval looks for a configuration for the combination of org and repo that contains
+	// the requested scope. If a match is made the scope is returned. This function also
+	// returns a string that represents the path to where the scope came from or the file that
+	// was being evaluated when an error occurred. This could be a local file path or a remote
+	// system such as GitHub.
 	Eval(ctx context.Context, org, repo, scope string, token interface{}) (*Scope, string, error)
 }
 

--- a/pkg/config/config_evaluator.go
+++ b/pkg/config/config_evaluator.go
@@ -36,14 +36,14 @@ const (
 type GitHubClientProvider func(ctx context.Context, org, repo string) (*github.Client, error)
 
 type ConfigEvaluator interface {
-	Eval(ctx context.Context, org, repo, scope string, token interface{}) (*Scope, error)
+	Eval(ctx context.Context, org, repo, scope string, token interface{}) (*Scope, string, error)
 }
 
 type configEvaluator struct {
 	loaders []ConfigFileLoader
 }
 
-func NewConfigEvaluator(expireAt time.Duration, localConfigDir, repoConfigPath, orgConfigPath, ref string, app *githubauth.App) (*configEvaluator, error) {
+func NewConfigEvaluator(expireAt time.Duration, localConfigDir, repoConfigPath, orgConfigRepo, orgConfigPath, ref string, app *githubauth.App) (*configEvaluator, error) {
 	// create an environment to compile any cel expressions
 	env, err := cel.NewEnv(
 		cel.Variable(assertionKey, cel.DynType),
@@ -58,16 +58,16 @@ func NewConfigEvaluator(expireAt time.Duration, localConfigDir, repoConfigPath, 
 	inRepoLoader := newCachingConfigLoader(expireAt,
 		NewCompilingConfigLoader(env, &ghInRepoConfigFileLoader{
 			provider:   makeGitHubClientProvider(app),
-			configPath: ".github/minty.yaml",
-			ref:        "main",
+			configPath: repoConfigPath,
+			ref:        ref,
 		}))
 	orgLoader := newCachingConfigLoader(expireAt,
 		NewCompilingConfigLoader(env, &fixedRepoConfigFileLoader{
-			repo: ".google-github",
+			repo: orgConfigRepo,
 			loader: &ghInRepoConfigFileLoader{
 				provider:   makeGitHubClientProvider(app),
-				configPath: "minty.yaml",
-				ref:        "main",
+				configPath: orgConfigPath,
+				ref:        ref,
 			},
 		}))
 	return &configEvaluator{
@@ -79,23 +79,24 @@ func NewConfigEvaluator(expireAt time.Duration, localConfigDir, repoConfigPath, 
 	}, nil
 }
 
-func (l *configEvaluator) Eval(ctx context.Context, org, repo, scope string, token interface{}) (*Scope, error) {
+func (l *configEvaluator) Eval(ctx context.Context, org, repo, scope string, token interface{}) (*Scope, string, error) {
 	for _, loader := range l.loaders {
+		source := loader.Source(org, repo)
 		contents, err := loader.Load(ctx, org, repo)
 		if err != nil {
-			return nil, fmt.Errorf("error reading configuration, child reader threw error: %w", err)
+			return nil, source, fmt.Errorf("error reading configuration, child reader threw error: %w", err)
 		}
 		if contents != nil {
 			s, err := contents.Eval(scope, token)
 			if err != nil {
-				return nil, fmt.Errorf("error evaluating scope: %w", err)
+				return nil, source, fmt.Errorf("error evaluating scope: %w", err)
 			}
 			if s != nil {
-				return s, nil
+				return s, source, nil
 			}
 		}
 	}
-	return nil, fmt.Errorf("error reading configuration, exhausted all possible source locations, failed to locate scope [%s] for repository [%s/%s]", scope, org, repo)
+	return nil, fmt.Sprintf("%s/%s", org, repo), fmt.Errorf("error reading configuration, exhausted all possible source locations, failed to locate scope [%s] for repository [%s/%s]", scope, org, repo)
 }
 
 func makeGitHubClientProvider(app *githubauth.App) GitHubClientProvider {

--- a/pkg/config/config_evaluator_test.go
+++ b/pkg/config/config_evaluator_test.go
@@ -34,6 +34,10 @@ func (l *testConfigFileLoader) Load(ctx context.Context, org, repo string) (*Con
 	return l.result, l.err
 }
 
+func (l *testConfigFileLoader) Source(org, repo string) string {
+	return fmt.Sprintf("mem://%s/%s", org, repo)
+}
+
 func TestOrderedConfigFileLoader(t *testing.T) {
 	t.Parallel()
 
@@ -371,7 +375,7 @@ func TestOrderedConfigFileLoader(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, err := tc.reader.Eval(ctx, tc.org, tc.repo, tc.scope, tc.token)
+			got, _, err := tc.reader.Eval(ctx, tc.org, tc.repo, tc.scope, tc.token)
 			if diff := cmp.Diff(tc.want, got, cmp.FilterPath(func(p cmp.Path) bool {
 				return !(p.Last().String() == "Program")
 			}, cmp.Ignore())); diff != "" {

--- a/pkg/mintycfg/runner.go
+++ b/pkg/mintycfg/runner.go
@@ -44,6 +44,10 @@ func (l *singleFileConfigLoader) Load(ctx context.Context, org, repo string) (*c
 	return config, nil
 }
 
+func (l *singleFileConfigLoader) Source(org, repo string) string {
+	return fmt.Sprintf("file://%s", l.filePath)
+}
+
 func Run(ctx context.Context, cfg *Config) error {
 	// create an environment to compile any cel expressions
 	env, err := cel.NewEnv(cel.Variable("assertion", cel.DynType))

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -27,7 +27,7 @@ import (
 type Config struct {
 	Port       string `env:"PORT,default=8080"`
 	AppID      string `env:"GITHUB_APP_ID,required"`
-	PrivateKey string `env:"GITHUB_PRIVATE_KEY,required"`
+	PrivateKey string `env:"GITHUB_PRIVATE_KEY,required" yaml:"-" json:"-"`
 	JWKSUrl    string `env:"GITHUB_JKWS_URL,default=https://token.actions.githubusercontent.com/.well-known/jwks"`
 
 	// GitHubAPIBaseURL is the base URL for the GitHub installation. It should
@@ -35,8 +35,9 @@ type Config struct {
 	GitHubAPIBaseURL string `env:"GITHUB_API_BASE_URL"`
 
 	ConfigDir          string `env:"CONFIGS_DIR,default=configs"`
-	RepoPath           string `env:"REPO_PATH,default=.github/minty.yaml"`
-	OrgPath            string `env:"ORG_PATH,default=.google-github/minty.yaml"`
+	RepoConfigPath     string `env:"REPO_CONFIG_PATH,default=.github/minty.yaml"`
+	OrgConfigRepo      string `env:"ORG_CONFIG_REPO,default=.google-github"`
+	OrgConfigPath      string `env:"ORG_CONFIG_PATH,default=minty.yaml"`
 	Ref                string `env:"REF,default=main"`
 	ConfigCacheSeconds string `env:"CONFIG_CACHE_SECONDS=900"`
 }
@@ -55,6 +56,20 @@ func (cfg *Config) Validate() error {
 	if cfg.ConfigCacheSeconds == "" {
 		cfg.ConfigCacheSeconds = "900"
 	}
+
+	if cfg.OrgConfigRepo == "" {
+		cfg.OrgConfigRepo = ".google-github"
+	}
+	if cfg.OrgConfigPath == "" {
+		cfg.OrgConfigPath = "minty.yaml"
+	}
+	if cfg.RepoConfigPath == "" {
+		cfg.RepoConfigPath = ".github/minty.yaml"
+	}
+	if cfg.Ref == "" {
+		cfg.Ref = "main"
+	}
+
 	return nil
 }
 
@@ -111,23 +126,30 @@ func (cfg *Config) ToFlags(set *cli.FlagSet) *cli.FlagSet {
 	})
 
 	f.StringVar(&cli.StringVar{
-		Name:   "repo-path",
-		Target: &cfg.RepoPath,
-		EnvVar: "REPO_PATH",
+		Name:   "repo-config-path",
+		Target: &cfg.RepoConfigPath,
+		EnvVar: "REPO_CONFIG_PATH",
 		Usage:  `The path to the minty configuration file in a repository.`,
 	})
 
 	f.StringVar(&cli.StringVar{
-		Name:   "org-path",
-		Target: &cfg.OrgPath,
-		EnvVar: "ORG_PATH",
+		Name:   "org-config-path",
+		Target: &cfg.OrgConfigPath,
+		EnvVar: "ORG_CONFIG_PATH",
 		Usage:  `The path to the minty configuration file for an organization.`,
+	})
+
+	f.StringVar(&cli.StringVar{
+		Name:   "org-config-repo",
+		Target: &cfg.OrgConfigRepo,
+		EnvVar: "ORG_CONFIG_REPO",
+		Usage:  `The repository that contains the configuration file for an organization.`,
 	})
 
 	f.StringVar(&cli.StringVar{
 		Name:   "ref",
 		Target: &cfg.Ref,
-		EnvVar: "REG",
+		EnvVar: "REF",
 		Usage:  `The ref (sha, branch, etc.) to look for configuration files at.`,
 	})
 

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -51,7 +51,15 @@ func Run(ctx context.Context, cfg *Config) error {
 		cacheSeconds = 1
 	}
 
-	store, err := config.NewConfigEvaluator(time.Duration(cacheSeconds)*time.Second, cfg.ConfigDir, cfg.RepoPath, cfg.OrgPath, cfg.Ref, app)
+	store, err := config.NewConfigEvaluator(
+		time.Duration(cacheSeconds)*time.Second,
+		cfg.ConfigDir,
+		cfg.RepoConfigPath,
+		cfg.OrgConfigRepo,
+		cfg.OrgConfigPath,
+		cfg.Ref,
+		app,
+	)
 	if err != nil {
 		return fmt.Errorf("failed to create config evaluator: %w", err)
 	}

--- a/pkg/server/token_minter_test.go
+++ b/pkg/server/token_minter_test.go
@@ -159,7 +159,7 @@ func TestTokenMintServer_ProcessRequest(t *testing.T) {
 			if err != nil {
 				t.Fatal(err)
 			}
-			configStore, err := config.NewConfigEvaluator(1*time.Hour, "../../testdata/configs", ".github/minty.yaml", ".google-github/minty.yaml", "main", githubApp)
+			configStore, err := config.NewConfigEvaluator(1*time.Hour, "../../testdata/configs", ".github/minty.yaml", ".google-github", "minty.yaml", "main", githubApp)
 			if err != nil {
 				t.Fatal(err)
 			}


### PR DESCRIPTION
* Fixed a few configuration options that weren't being used
* Adjusted logging levels for startup configuration details
* Added additional logging in the config loaders to output the path to where the configuration is coming from e.g. `https://github.com/abcxyz/github-token-minter/.github/minty.yaml`. This will help when a scope doesn't resolve so we are sure its looking in the correct files.