### PR TITLE
feat: add verification for non-github oidc tokens

### DIFF
--- a/pkg/server/claims.go
+++ b/pkg/server/claims.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/lestrrat-go/jwx/v2/jws"
 	"github.com/lestrrat-go/jwx/v2/jwt"
 
 	"github.com/abcxyz/github-token-minter/pkg/config"
@@ -29,6 +30,7 @@ import (
 // a JWT auth token into a set of OIDC claims.
 type JWTParser struct {
 	ParseOptions []jwt.ParseOption
+	jwkResolver  JWKResolver
 }
 
 // oidcClaims is an object that contains all of the expected
@@ -92,8 +94,16 @@ func (c *oidcClaims) asMap() map[string]interface{} {
 
 // parseAuthToken converts a JWT token into a collection of OIDC claims.
 func (p *JWTParser) parseAuthToken(ctx context.Context, oidcHeader string) (*oidcClaims, *apiResponse) {
+	keySet, err := p.jwkResolver.ResolveKeySet(ctx, oidcHeader)
+	if err != nil {
+		return nil, &apiResponse{
+			http.StatusUnauthorized,
+			fmt.Sprintf("request not authorized: could not resolve JWK keys"),
+			fmt.Errorf("failed to validate jwt: %w", err),
+		}
+	}
 	// Parse the token data into a JWT
-	parseOpts := append([]jwt.ParseOption{jwt.WithContext(ctx)}, p.ParseOptions...)
+	parseOpts := append([]jwt.ParseOption{jwt.WithContext(ctx), jwt.WithKeySet(keySet, jws.WithInferAlgorithmFromKey(true))}, p.ParseOptions...)
 	oidcToken, err := jwt.Parse([]byte(oidcHeader), parseOpts...)
 	if err != nil {
 		return nil, &apiResponse{

--- a/pkg/server/claims.go
+++ b/pkg/server/claims.go
@@ -98,7 +98,7 @@ func (p *JWTParser) parseAuthToken(ctx context.Context, oidcHeader string) (*oid
 	if err != nil {
 		return nil, &apiResponse{
 			http.StatusUnauthorized,
-			fmt.Sprintf("request not authorized: could not resolve JWK keys"),
+			"request not authorized: could not resolve JWK keys",
 			fmt.Errorf("failed to validate jwt: %w", err),
 		}
 	}

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -18,6 +18,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/abcxyz/github-token-minter/pkg/config"
 	"github.com/abcxyz/pkg/cli"
 )
 
@@ -147,7 +148,7 @@ func (cfg *Config) ToFlags(set *cli.FlagSet) *cli.FlagSet {
 		Name:    "jwks-cache-duration",
 		Target:  &cfg.JWKSCacheDuration,
 		EnvVar:  "JWKS_CACHE_DURATION",
-		Usage:   `The duration to cache the JWKS for an OIDC token issuer. Defaults to 4 hours.`,
+		Usage:   `The duration for which to cache the JWKS for an OIDC token issuer.`,
 		Default: 4 * time.Hour,
 	})
 
@@ -155,7 +156,7 @@ func (cfg *Config) ToFlags(set *cli.FlagSet) *cli.FlagSet {
 		Name:    "issuer-allowlist",
 		Target:  &cfg.IssuerAllowlist,
 		EnvVar:  "ISSUER_ALLOWLIST",
-		Usage:   `The list of OIDC token issuers that GitHub Token Minter will accept. Format is a comma-separated list of URLs. Defaults to GitHub and Google issuers.`,
+		Usage:   `The list of OIDC token issuers that GitHub Token Minter will accept. Format is a comma-separated list of URLs or the flag can be specified multiple times.`,
 		Default: []string{config.GitHubIssuer, config.GoogleIssuer},
 	})
 

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -144,17 +144,19 @@ func (cfg *Config) ToFlags(set *cli.FlagSet) *cli.FlagSet {
 	})
 
 	f.DurationVar(&cli.DurationVar{
-		Name:   "jwks-cache-duration",
-		Target: &cfg.JWKSCacheDuration,
-		EnvVar: "JWKS_CACHE_DURATION",
-		Usage:  `The duration to cache the JWKS for an OIDC token issuer. Defaults to 4 hours.`,
+		Name:    "jwks-cache-duration",
+		Target:  &cfg.JWKSCacheDuration,
+		EnvVar:  "JWKS_CACHE_DURATION",
+		Usage:   `The duration to cache the JWKS for an OIDC token issuer. Defaults to 4 hours.`,
+		Default: 4 * time.Hour,
 	})
 
 	f.StringSliceVar(&cli.StringSliceVar{
-		Name:   "issuer-allowlist",
-		Target: &cfg.IssuerAllowlist,
-		EnvVar: "ISSUER_ALLOWLIST",
-		Usage:  `The list of OIDC token issuers that GitHub Token Minter will accept. Format is a comma-separated list of URLs. Defaults to GitHub and Google issuers.`,
+		Name:    "issuer-allowlist",
+		Target:  &cfg.IssuerAllowlist,
+		EnvVar:  "ISSUER_ALLOWLIST",
+		Usage:   `The list of OIDC token issuers that GitHub Token Minter will accept. Format is a comma-separated list of URLs. Defaults to GitHub and Google issuers.`,
+		Default: []string{config.GitHubIssuer, config.GoogleIssuer},
 	})
 
 	return set

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -16,9 +16,8 @@ package server
 
 import (
 	"fmt"
-	"strings"
+	"time"
 
-	"github.com/abcxyz/github-token-minter/pkg/config"
 	"github.com/abcxyz/pkg/cli"
 )
 
@@ -38,8 +37,8 @@ type Config struct {
 	Ref                string
 	ConfigCacheSeconds string
 
-	JWKSURICacheSeconds string
-	IssuerAllowlist     string
+	JWKSURICacheDuration time.Duration
+	IssuerAllowlist      []string
 }
 
 // Validate validates the artifacts config after load.
@@ -65,14 +64,6 @@ func (cfg *Config) Validate() error {
 	}
 	if cfg.Ref == "" {
 		cfg.Ref = "main"
-	}
-
-	if cfg.JWKSURICacheSeconds == "" {
-		// 4 hours default
-		cfg.JWKSURICacheSeconds = "14400"
-	}
-	if cfg.IssuerAllowlist == "" {
-		cfg.IssuerAllowlist = strings.Join([]string{config.GitHubIssuer, config.GoogleIssuer}, ",")
 	}
 
 	return nil
@@ -152,14 +143,14 @@ func (cfg *Config) ToFlags(set *cli.FlagSet) *cli.FlagSet {
 		Usage:  `The number of minutes to cache configuration files before retrieving fresh ones. Defaults to 15 minutes.`,
 	})
 
-	f.StringVar(&cli.StringVar{
-		Name:   "jwks-uri-cache-seconds",
-		Target: &cfg.JWKSURICacheSeconds,
-		EnvVar: "JWKS_URI_CACHE_SECONDS",
-		Usage:  `The number of seconds to cache the jwks_uri from an OIDC token issuer's OpenID Configuration before retrieving fresh ones. Defaults to 4 hours.`,
+	f.DurationVar(&cli.DurationVar{
+		Name:   "jwks-uri-cache-duration",
+		Target: &cfg.JWKSURICacheDuration,
+		EnvVar: "JWKS_URI_CACHE_DURATION",
+		Usage:  `The duration to cache the jwks_uri from an OIDC token issuer's OpenID Configuration before retrieving fresh ones. Defaults to 4 hours.`,
 	})
 
-	f.StringVar(&cli.StringVar{
+	f.StringSliceVar(&cli.StringSliceVar{
 		Name:   "issuer-allowlist",
 		Target: &cfg.IssuerAllowlist,
 		EnvVar: "ISSUER_ALLOWLIST",

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -37,8 +37,8 @@ type Config struct {
 	Ref                string
 	ConfigCacheSeconds string
 
-	JWKSURICacheDuration time.Duration
-	IssuerAllowlist      []string
+	JWKSCacheDuration time.Duration
+	IssuerAllowlist   []string
 }
 
 // Validate validates the artifacts config after load.
@@ -144,10 +144,10 @@ func (cfg *Config) ToFlags(set *cli.FlagSet) *cli.FlagSet {
 	})
 
 	f.DurationVar(&cli.DurationVar{
-		Name:   "jwks-uri-cache-duration",
-		Target: &cfg.JWKSURICacheDuration,
-		EnvVar: "JWKS_URI_CACHE_DURATION",
-		Usage:  `The duration to cache the jwks_uri from an OIDC token issuer's OpenID Configuration before retrieving fresh ones. Defaults to 4 hours.`,
+		Name:   "jwks-cache-duration",
+		Target: &cfg.JWKSCacheDuration,
+		EnvVar: "JWKS_CACHE_DURATION",
+		Usage:  `The duration to cache the JWKS for an OIDC token issuer. Defaults to 4 hours.`,
 	})
 
 	f.StringSliceVar(&cli.StringSliceVar{

--- a/pkg/server/jwk_resolver.go
+++ b/pkg/server/jwk_resolver.go
@@ -43,10 +43,10 @@ type OpenIDConfiguration struct {
 	JwksURI string `json:"jwks_uri"`
 }
 
-func NewOIDCResolver(ctx context.Context, issuerAllowlist []string, jwksURICacheTimeout time.Duration) *OIDCResolver {
+func NewOIDCResolver(ctx context.Context, issuerAllowlist []string, cacheTimeout time.Duration) *OIDCResolver {
 	return &OIDCResolver{
 		issuerAllowlist: issuerAllowlist,
-		cache:           cache.New[jwk.Set](jwksURICacheTimeout),
+		cache:           cache.New[jwk.Set](cacheTimeout),
 	}
 }
 

--- a/pkg/server/jwk_resolver.go
+++ b/pkg/server/jwk_resolver.go
@@ -56,7 +56,7 @@ func NewOIDCResolver(ctx context.Context, issuerAllowlist []string, jwksURICache
 
 func (r *OIDCResolver) ResolveKeySet(ctx context.Context, oidcHeader string) (jwk.Set, error) {
 	// Parse without verification to extract issuer so we can use it to obtain the key set to use for verification
-	token, err := jwt.ParseString(oidcHeader, jwt.WithContext(ctx), jwt.WithVerify(false))
+	token, err := jwt.ParseString(oidcHeader, jwt.WithContext(ctx), jwt.WithVerify(false), jwt.WithValidate(false))
 	if err != nil {
 		return nil, fmt.Errorf("failed to parse issuer from jwt header: %w", err)
 	}

--- a/pkg/server/jwk_resolver.go
+++ b/pkg/server/jwk_resolver.go
@@ -54,6 +54,7 @@ func NewOIDCResolver(ctx context.Context, issuerAllowlist []string, jwksURICache
 	}
 }
 
+// ResolveKeySet finds and caches the correct OIDC key set to use based on the token's issuer's OpenID Configuration.
 func (r *OIDCResolver) ResolveKeySet(ctx context.Context, oidcHeader string) (jwk.Set, error) {
 	// Parse without verification to extract issuer so we can use it to obtain the key set to use for verification
 	token, err := jwt.ParseString(oidcHeader, jwt.WithContext(ctx), jwt.WithVerify(false), jwt.WithValidate(false))

--- a/pkg/server/jwk_resolver.go
+++ b/pkg/server/jwk_resolver.go
@@ -75,7 +75,7 @@ func (r *OIDCResolver) ResolveKeySet(ctx context.Context, oidcHeader string) (jw
 		return keySet, nil
 	})
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("failed to resolve key set: %w", err)
 	}
 
 	return keySet, nil

--- a/pkg/server/jwk_resolver.go
+++ b/pkg/server/jwk_resolver.go
@@ -1,0 +1,119 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+)
+
+type JWKResolver interface {
+	ResolveKeySet(ctx context.Context, oidcHeader string) (jwk.Set, error)
+}
+
+type OIDCResolver struct {
+	cache           *jwk.Cache
+	issuerToJwksURI map[string]string
+}
+
+type OpenIDConfiguration struct {
+	// The only field we need from the config
+	JwksURI string `json:"jwks_uri"`
+}
+
+func NewOIDCResolver(ctx context.Context) *OIDCResolver {
+	return &OIDCResolver{
+		cache:           jwk.NewCache(ctx),
+		issuerToJwksURI: map[string]string{},
+	}
+}
+
+func (r *OIDCResolver) ResolveKeySet(ctx context.Context, oidcHeader string) (jwk.Set, error) {
+	issuer, err := r.extractIssuer(ctx, oidcHeader)
+	if err != nil {
+		return nil, fmt.Errorf("failed to extract issuer from token: %w", err)
+	}
+
+	err = r.registerIssuer(issuer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to register issuer %q: %w", issuer, err)
+	}
+
+	return jwk.NewCachedSet(r.cache, r.issuerToJwksURI[issuer]), nil
+}
+
+func (r *OIDCResolver) extractIssuer(ctx context.Context, oidcHeader string) (string, error) {
+	// Parse without validation to extract issuer so we can use it to obtain the key set to use for validation
+	token, err := jwt.ParseString(oidcHeader, jwt.WithContext(ctx), jwt.WithVerify(false))
+	if err != nil {
+		return "", fmt.Errorf("failed to parse jwt header: %w", err)
+	}
+	return token.Issuer(), nil
+}
+
+func (r *OIDCResolver) registerIssuer(issuer string) error {
+	jwksURI, err := r.resolveJwksURI(issuer)
+	if err != nil {
+		return fmt.Errorf("failed to resolve JWKS URI for %q: %w", issuer, err)
+	}
+
+	if !r.cache.IsRegistered(jwksURI) {
+		err = r.cache.Register(jwksURI)
+		if err != nil {
+			return fmt.Errorf("failed to register JWKS URI %q to cache: %w", jwksURI, err)
+		}
+	}
+
+	return nil
+}
+
+func (r *OIDCResolver) resolveJwksURI(issuer string) (string, error) {
+	uri, cached := r.issuerToJwksURI[issuer]
+	if cached {
+		return uri, nil
+	}
+
+	configURL, err := url.JoinPath(issuer, ".well-known", "openid-configuration")
+	if err != nil {
+		return "", fmt.Errorf("error processing issuer URL %q: %w", issuer, err)
+	}
+
+	resp, err := http.Get(configURL)
+	if err != nil {
+		return "", fmt.Errorf("error fetching OpenID Configuration from %q: %w", configURL, err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return "", fmt.Errorf("failed to read response body from GET %q: %w", configURL, err)
+	}
+
+	var config OpenIDConfiguration
+	err = json.Unmarshal(body, &config)
+	if err != nil {
+		return "", fmt.Errorf("failed to unmarshal OpenID Configuration: %w", err)
+	}
+
+	r.issuerToJwksURI[issuer] = config.JwksURI
+
+	return config.JwksURI, nil
+}

--- a/pkg/server/jwk_resolver_test.go
+++ b/pkg/server/jwk_resolver_test.go
@@ -1,0 +1,82 @@
+// Copyright 2023 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package server
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"testing"
+
+	"github.com/lestrrat-go/jwx/v2/jwt"
+
+	"github.com/abcxyz/github-token-minter/pkg/config"
+	"github.com/abcxyz/pkg/logging"
+	"github.com/abcxyz/pkg/testutil"
+)
+
+func TestJWKResolver(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.WithLogger(context.Background(), logging.TestLogger(t))
+	resolver := NewOIDCResolver(ctx)
+
+	signer, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name   string
+		issuer string
+		expErr string
+	}{
+		{
+			name:   "github",
+			issuer: config.GitHubIssuer,
+		},
+		{
+			name:   "google",
+			issuer: config.GoogleIssuer,
+		},
+		{
+			name:   "invalid-issuer",
+			issuer: "https://fakeurlthatdoesnotexist.com",
+			expErr: "error fetching OpenID Configuration",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			tokenString := testTokenBuilder(t, signer, func(b *jwt.Builder) {
+				b.Issuer(tc.issuer)
+			})
+
+			keySet, err := resolver.ResolveKeySet(ctx, tokenString)
+
+			if diff := testutil.DiffErrString(err, tc.expErr); diff != "" {
+				t.Errorf(diff)
+			}
+
+			if tc.expErr == "" && keySet.Len() == 0 {
+				t.Errorf("key set should not be empty for real issuer %q", tc.issuer)
+			}
+		})
+	}
+}

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"strconv"
+	"strings"
 	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwt"
@@ -66,8 +67,14 @@ func Run(ctx context.Context, cfg *Config) error {
 		jwt.WithAcceptableSkew(5 * time.Second),
 	}
 
+	jwksURICacheSeconds, err := strconv.Atoi(cfg.JWKSURICacheSeconds)
+	if err != nil {
+		return fmt.Errorf("failed to parse jwks uri cache seconds as an integer: %w", err)
+	}
+	jwkResolver := NewOIDCResolver(ctx, strings.Split(cfg.IssuerAllowlist, ","), time.Duration(jwksURICacheSeconds)*time.Second)
+
 	// Create the Router for the token minting server.
-	tokenServer, err := NewRouter(ctx, app, store, &JWTParser{ParseOptions: jwtParseOptions, jwkResolver: NewOIDCResolver(ctx)})
+	tokenServer, err := NewRouter(ctx, app, store, &JWTParser{ParseOptions: jwtParseOptions, jwkResolver: jwkResolver})
 	if err != nil {
 		return fmt.Errorf("failed to start token mint server: %w", err)
 	}

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"fmt"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/lestrrat-go/jwx/v2/jwt"
@@ -67,11 +66,7 @@ func Run(ctx context.Context, cfg *Config) error {
 		jwt.WithAcceptableSkew(5 * time.Second),
 	}
 
-	jwksURICacheSeconds, err := strconv.Atoi(cfg.JWKSURICacheSeconds)
-	if err != nil {
-		return fmt.Errorf("failed to parse jwks uri cache seconds as an integer: %w", err)
-	}
-	jwkResolver := NewOIDCResolver(ctx, strings.Split(cfg.IssuerAllowlist, ","), time.Duration(jwksURICacheSeconds)*time.Second)
+	jwkResolver := NewOIDCResolver(ctx, cfg.IssuerAllowlist, cfg.JWKSURICacheDuration)
 
 	// Create the Router for the token minting server.
 	tokenServer, err := NewRouter(ctx, app, store, &JWTParser{ParseOptions: jwtParseOptions, jwkResolver: jwkResolver})

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -66,7 +66,7 @@ func Run(ctx context.Context, cfg *Config) error {
 		jwt.WithAcceptableSkew(5 * time.Second),
 	}
 
-	jwkResolver := NewOIDCResolver(ctx, cfg.IssuerAllowlist, cfg.JWKSURICacheDuration)
+	jwkResolver := NewOIDCResolver(ctx, cfg.IssuerAllowlist, cfg.JWKSCacheDuration)
 
 	// Create the Router for the token minting server.
 	tokenServer, err := NewRouter(ctx, app, store, &JWTParser{ParseOptions: jwtParseOptions, jwkResolver: jwkResolver})


### PR DESCRIPTION
* Dynamically resolve JWK key set used for token verification based on token's issuer URL and OpenID Configuration and cache key sets in the same way that we do in [JVS](https://github.com/abcxyz/jvs/blob/main/apis/v0/client.go#L36-L39). 
* Cache `jwks_uri` for issuers with a command line configured (default 4 hours) TTL (these should very rarely change) so we don't have to GET the OpenID Configs often. 
* Command line configured allowlist of issuers, defaulting to just GitHub and Google