### PR TITLE
feat: support non-GitHub OIDC tokens

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -29,8 +29,14 @@ const (
 	configVersionV2 = "minty.abcxyz.dev/v2"
 )
 
+const (
+	GitHubIssuer = "https://token.actions.githubusercontent.com"
+	GoogleIssuer = "https://accounts.google.com"
+)
+
 var issuersMap = map[string]string{
-	"github": "https://token.actions.githubusercontent.com",
+	"github": GitHubIssuer,
+	"google": GoogleIssuer,
 }
 
 // Rule is a struct that contains the string representation

--- a/pkg/server/claims.go
+++ b/pkg/server/claims.go
@@ -20,8 +20,9 @@ import (
 	"net/http"
 	"strings"
 
-	"github.com/abcxyz/github-token-minter/pkg/config"
 	"github.com/lestrrat-go/jwx/v2/jwt"
+
+	"github.com/abcxyz/github-token-minter/pkg/config"
 )
 
 // JWTParser is an object that is responsible for parsing


### PR DESCRIPTION
* Extract minty config GitHub repository from token's `aud` field