### PR TITLE
Allow correct integration service account in minty cfg

### DIFF
--- a/.github/minty.yaml
+++ b/.github/minty.yaml
@@ -8,7 +8,7 @@ rule:
       assertion.repository_id == '576289489'
     ) || (
       assertion.iss == issuers.google &&
-      assertion.sub == '112892967544648233217' // integration WIF service account
+      assertion.email == "github-automation-bot@gha-ghtm-ci-i-647d53.iam.gserviceaccount.com" // integration CI service account
     )
 
 scope:
@@ -29,7 +29,7 @@ scope:
       if: |-
         assertion.workflow_ref.startsWith("abcxyz/github-token-minter/.github/workflows/ci.yml") || (
           assertion.iss == issuers.google &&
-          assertion.sub == "112892967544648233217" // integration WIF service account
+          assertion.email == "github-automation-bot@gha-ghtm-ci-i-647d53.iam.gserviceaccount.com" // integration CI service account
         )
     repositories:
       - 'github-token-minter'


### PR DESCRIPTION
Previously I allowlisted the wrong service account. This is the one actually calling token minter from the CI integration flow, verified by logs.  