### PR TITLE
Add integration test for mint-token action against production token minter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,8 +209,8 @@ jobs:
         with:
           wif_provider: '${{ vars.TOKEN_MINTER_WIF_PROVIDER }}'
           wif_service_account: '${{ vars.TOKEN_MINTER_WIF_SERVICE_ACCOUNT }}'
-          service_audience: '${{ env.TOKEN_MINTER_SERVICE_AUDIENCE }}'
-          service_url: '${{ env.TOKEN_MINTER_SERVICE_URL }}'
+          service_audience: '${{ vars.TOKEN_MINTER_SERVICE_AUDIENCE }}'
+          service_url: '${{ vars.TOKEN_MINTER_SERVICE_URL }}'
           requested_permissions: '{"scope":"integ","repositories":["github-token-minter"],"permissions":{"issues":"read"}}'
 
       - name: 'verify-prod-github-token'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -203,3 +203,20 @@ jobs:
             -H "Authorization: Bearer $token"\
             -H "X-GitHub-Api-Version: 2022-11-28" \
             https://api.github.com/repos/abcxyz/github-token-minter/issues/events
+
+      - id: 'mint-prod-github-token'
+        uses: './.github/actions/mint-token'
+        with:
+          wif_provider: '${{ vars.TOKEN_MINTER_WIF_PROVIDER }}'
+          wif_service_account: '${{ vars.TOKEN_MINTER_WIF_SERVICE_ACCOUNT }}'
+          service_audience: '${{ env.TOKEN_MINTER_SERVICE_AUDIENCE }}'
+          service_url: '${{ env.TOKEN_MINTER_SERVICE_URL }}'
+          requested_permissions: '{"scope":"integ","repositories":["github-token-minter"],"permissions":{"issues":"read"}}'
+
+      - name: 'verify-prod-github-token'
+        run: |
+          curl --fail \
+            -H "Accept: application/vnd.github+json" \
+            -H "Authorization: Bearer ${{ steps.mint-prod-github-token.outputs.token }}"\
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/abcxyz/github-token-minter/issues/events


### PR DESCRIPTION
Sometimes changes to the mint-token action will work with the latest version of token minter but not with the version currently deployed to production, which causes issues. This test is to catch those cases. 