### PR TITLE
chore: add a passthrough for environment variables into the terraform module to the cloud run service

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -65,6 +65,8 @@ module "cloud_run" {
     invokers   = toset(concat(var.service_iam.invokers, [google_service_account.wif_service_account.member]))
   }
 
+  envvars = var.envvars
+
   secret_envvars = {
     "GITHUB_APP_ID" : {
       name : "github-application-id",

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -87,3 +87,9 @@ variable "alerts" {
     }
   }
 }
+
+variable "envvars" {
+  type        = map(string)
+  default     = {}
+  description = "Environment variables for the Cloud Run service (plain text)."
+}


### PR DESCRIPTION
Adding a blanket passthrough so that users can set any additional environment variables that they may need rather than specifying the 8 possible existing environment variables separately. This will set us up for any future environment configuration to not require updates to the terraform module.