### PR TITLE
feat: Update WIF pool assertions to allow for enterprise id and/or organization id

### DIFF
--- a/pkg/server/claims.go
+++ b/pkg/server/claims.go
@@ -63,6 +63,8 @@ type oidcClaims struct {
 	JobWorkflowSha    string `json:"job_workflow_sha"`
 	ParsedOrgName     string `json:"parsed_org_name"`
 	ParsedRepoName    string `json:"parsed_repo_name"`
+	EnterpriseName    string `json:"enterprise"`
+	EnterpriseID      string `json:"enterprise_id"`
 
 	// Google claims
 	Email string `json:"email"`
@@ -95,6 +97,8 @@ func (c *oidcClaims) asMap() map[string]interface{} {
 		"parsed_org_name":     c.ParsedOrgName,
 		"parsed_repo_name":    c.ParsedRepoName,
 		"email":               c.Email,
+		"enterprise":          c.EnterpriseName,
+		"enterprise_id":       c.EnterpriseID,
 	}
 }
 
@@ -161,6 +165,8 @@ func parsePrivateClaims(oidcToken jwt.Token) (*oidcClaims, error) {
 	claims.WorkflowSha = optionalClaim[string](oidcToken, "workflow_sha")
 	claims.JobWorkflowRef = optionalClaim[string](oidcToken, "job_workflow_ref")
 	claims.JobWorkflowSha = optionalClaim[string](oidcToken, "job_workflow_sha")
+	claims.EnterpriseName = optionalClaim[string](oidcToken, "enterprise")
+	claims.EnterpriseID = optionalClaim[string](oidcToken, "enterprise_id")
 
 	emailVerified := optionalClaim[bool](oidcToken, "email_verified")
 	if emailVerified {

--- a/terraform/github-wif.tf
+++ b/terraform/github-wif.tf
@@ -18,8 +18,11 @@ locals {
     "attribute.actor" : "assertion.actor"
     "attribute.aud" : "assertion.aud"
     "attribute.repository_owner_id" : "assertion.repository_owner_id"
+    "attribute.enterprise_id" : "assertion.enterprise_id"
   }
-  wif_attribute_condition = var.github_owner_id != "" ? "attribute.repository_owner_id == \"${var.github_owner_id}\"" : ""
+  wif_attr_org_id        = var.github_owner_id != "" ? "attribute.repository_owner_id == \"${var.github_owner_id}\"" : ""
+  wif_attr_enterprise_id = var.github_enterprise_id != "" ? "attribute.enterprise_id == \"${var.github_enterprise_id}\"" : ""
+
 }
 
 resource "google_iam_workload_identity_pool" "default" {
@@ -43,7 +46,7 @@ resource "google_iam_workload_identity_pool_provider" "default" {
   description                        = "${var.name} OIDC identity provider"
 
   attribute_mapping   = local.wif_attribute_mapping
-  attribute_condition = local.wif_attribute_condition
+  attribute_condition = var.github_owner_id != "" && var.github_enterprise_id != "" ? local.wif_attr_org_id + " && " + local.wif_attr_enterprise_id : local.wif_attr_org_id + local.wif_attr_enterprise_id
 
   oidc {
     issuer_uri = "https://token.actions.githubusercontent.com"

--- a/terraform/github-wif.tf
+++ b/terraform/github-wif.tf
@@ -19,7 +19,7 @@ locals {
     "attribute.aud" : "assertion.aud"
     "attribute.repository_owner_id" : "assertion.repository_owner_id"
   }
-  wif_attribute_condition = "attribute.repository_owner_id == \"${var.github_owner_id}\""
+  wif_attribute_condition = var.github_owner_id != "" ? "attribute.repository_owner_id == \"${var.github_owner_id}\"" : ""
 }
 
 resource "google_iam_workload_identity_pool" "default" {

--- a/terraform/github-wif.tf
+++ b/terraform/github-wif.tf
@@ -46,7 +46,7 @@ resource "google_iam_workload_identity_pool_provider" "default" {
   description                        = "${var.name} OIDC identity provider"
 
   attribute_mapping   = local.wif_attribute_mapping
-  attribute_condition = var.github_owner_id != "" && var.github_enterprise_id != "" ? local.wif_attr_org_id + " && " + local.wif_attr_enterprise_id : local.wif_attr_org_id + local.wif_attr_enterprise_id
+  attribute_condition = join(" && ", compact([local.wif_attr_enterprise_id, local.wif_attr_org_id]))
 
   oidc {
     issuer_uri = "https://token.actions.githubusercontent.com"

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -66,8 +66,9 @@ variable "ci_service_account_member" {
 }
 
 variable "github_owner_id" {
-  description = "The ID of the GitHub organization."
+  description = "The ID of the GitHub organization. If specified, the WIF pool will limit traffic to a single GitHub organization."
   type        = string
+  default     = ""
 }
 
 variable "alerts" {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -71,6 +71,12 @@ variable "github_owner_id" {
   default     = ""
 }
 
+variable "github_enterprise_id" {
+  description = "The ID of the GitHub enterprise. If specified, the WIF pool will limit traffic to a single GitHub enterprise."
+  type        = string
+  default     = ""
+}
+
 variable "alerts" {
   description = "The configuration block for token minter service alerts and notifications"
   type = object({


### PR DESCRIPTION
This will allow us to deploy instances of minty for multiple organizations.