### PR TITLE
feat: extracted GitHub specific code into an isolated class

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	github.com/google/go-github/v64 v64.0.0
 	github.com/google/tink/go v1.7.0
 	github.com/lestrrat-go/jwx/v2 v2.1.3
+	github.com/sethvargo/go-gcpkms v0.3.0
 	github.com/sethvargo/go-retry v0.3.0
 	google.golang.org/api v0.221.0
 	google.golang.org/grpc v1.70.0

--- a/go.sum
+++ b/go.sum
@@ -82,6 +82,8 @@ github.com/rogpeppe/go-internal v1.13.1 h1:KvO1DLK/DRN07sQ1LQKScxyZJuNnedQ5/wKSR
 github.com/rogpeppe/go-internal v1.13.1/go.mod h1:uMEvuHeurkdAXX61udpOXGD/AzZDWNMNyH2VO9fmH0o=
 github.com/segmentio/asm v1.2.0 h1:9BQrFxC+YOHJlTlHGkTrFWf59nbL3XnCoFLTwDCI7ys=
 github.com/segmentio/asm v1.2.0/go.mod h1:BqMnlJP91P8d+4ibuonYZw9mfnzI9HfxselHZr5aAcs=
+github.com/sethvargo/go-gcpkms v0.3.0 h1:eYBNlMGOQ2EcqSQZMxwWYGJiqxFeU5jeFOuXPHzkhuo=
+github.com/sethvargo/go-gcpkms v0.3.0/go.mod h1:GL2QgumjGh1Bvt9seC3nA9s+RnqS4pxRA/4X/ySHF7E=
 github.com/sethvargo/go-retry v0.3.0 h1:EEt31A35QhrcRZtrYFDTBg91cqZVnFL2navjDrah2SE=
 github.com/sethvargo/go-retry v0.3.0/go.mod h1:mNX17F0C/HguQMyMyJxcnU471gOZGxCLyYaFyAZraas=
 github.com/stoewer/go-strcase v1.3.0 h1:g0eASXYtp+yvN9fK8sH94oCIk0fau9uV1/ZdJ0AVEzs=

--- a/pkg/cli/root.go
+++ b/pkg/cli/root.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package cli implements the commands for the github-metrics-aggregator CLI.
+// Package cli implements the commands for the github-token-minter CLI.
 package cli
 
 import (

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -46,7 +46,7 @@ type Config struct {
 }
 
 const (
-	SourceSystemAuthConfigRegex = `gha\:\/\/(\d+)\?(private_key|kms_id)=(.*)`
+	SourceSystemAuthConfigRegex = `gha\:\/\/(\d+)\?(private_key|kms_id)=([\s\S]*)`
 )
 
 // Validate validates the artifacts config after load.
@@ -84,8 +84,8 @@ func (cfg *Config) Validate() error {
 	if len(cfg.SourceSystemAuth) != 1 {
 		// Limit this to a single source system for now.
 		// @TODO(bradegler) - remove this constraint in the future when it is understood how to target
-		// specific systems.
-		return fmt.Errorf("incorrect number of authentication sources specified - SOURCE_SYSTEM_AUTH should only contain 1 value.")
+		// specific systems
+		return fmt.Errorf("incorrect number of authentication sources specified - SOURCE_SYSTEM_AUTH should only contain 1 value")
 	}
 
 	for _, auth := range cfg.SourceSystemAuth {

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -81,6 +81,13 @@ func (cfg *Config) Validate() error {
 	if err != nil {
 		return fmt.Errorf("failed to compile source system regular expression: %w", err)
 	}
+	if len(cfg.SourceSystemAuth) != 1 {
+		// Limit this to a single source system for now.
+		// @TODO(bradegler) - remove this constraint in the future when it is understood how to target
+		// specific systems.
+		return fmt.Errorf("incorrect number of authentication sources specified - SOURCE_SYSTEM_AUTH should only contain 1 value.")
+	}
+
 	for _, auth := range cfg.SourceSystemAuth {
 		if !re.MatchString(auth) {
 			return fmt.Errorf("incorrect source system authentication uri: %s - should match expression %s", auth, SourceSystemAuthConfigRegex)

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -16,33 +16,36 @@ package server
 
 import (
 	"context"
+	"crypto"
 	"fmt"
+	"regexp"
 	"strconv"
 	"time"
 
+	kms "cloud.google.com/go/kms/apiv1"
 	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/sethvargo/go-gcpkms/pkg/gcpkms"
 
 	"github.com/abcxyz/github-token-minter/pkg/config"
+	"github.com/abcxyz/github-token-minter/pkg/server/source"
 	"github.com/abcxyz/pkg/githubauth"
 	"github.com/abcxyz/pkg/serving"
 )
 
+const (
+	KeyTypePrivateKey = "private_key"
+	KeyTypeKMSID      = "kms_id"
+)
+
 func Run(ctx context.Context, cfg *Config) error {
-	// Set the access token url pattern if it is provided.
-	var options []githubauth.Option
-	if cfg.GitHubAPIBaseURL != "" {
-		options = append(options, githubauth.WithBaseURL(cfg.GitHubAPIBaseURL))
+	appConfigs, err := createAppConfigs(ctx, cfg)
+	if err != nil {
+		return fmt.Errorf("failed to generate app configs: %w", err)
 	}
 
-	signer, err := githubauth.NewPrivateKeySigner(cfg.PrivateKey)
+	sourceSystem, err := source.NewGitHubSourceSystem(ctx, appConfigs, cfg.SourceSystemAPIBaseURL)
 	if err != nil {
-		return fmt.Errorf("failed to create private key signer: %w", err)
-	}
-
-	// Setup the GitHub App.
-	app, err := githubauth.NewApp(cfg.AppID, signer, options...)
-	if err != nil {
-		return fmt.Errorf("failed to create github app: %w", err)
+		return fmt.Errorf("failed to initialize source system: %w", err)
 	}
 
 	cacheSeconds, err := strconv.Atoi(cfg.ConfigCacheSeconds)
@@ -61,7 +64,7 @@ func Run(ctx context.Context, cfg *Config) error {
 		cfg.OrgConfigRepo,
 		cfg.OrgConfigPath,
 		cfg.Ref,
-		app,
+		sourceSystem,
 	)
 	if err != nil {
 		return fmt.Errorf("failed to create config evaluator: %w", err)
@@ -74,7 +77,7 @@ func Run(ctx context.Context, cfg *Config) error {
 	jwkResolver := NewOIDCResolver(ctx, cfg.IssuerAllowlist, cfg.JWKSCacheDuration)
 
 	// Create the Router for the token minting server.
-	tokenServer, err := NewRouter(ctx, app, store, &JWTParser{ParseOptions: jwtParseOptions, jwkResolver: jwkResolver})
+	tokenServer, err := NewRouter(ctx, sourceSystem, store, &JWTParser{ParseOptions: jwtParseOptions, jwkResolver: jwkResolver})
 	if err != nil {
 		return fmt.Errorf("failed to start token mint server: %w", err)
 	}
@@ -88,4 +91,63 @@ func Run(ctx context.Context, cfg *Config) error {
 		return fmt.Errorf("failed to start HTTP server: %w", err)
 	}
 	return nil
+}
+
+func createAppConfigs(ctx context.Context, cfg *Config) ([]*source.GitHubAppConfig, error) {
+	appConfigs := make([]*source.GitHubAppConfig, 0, len(cfg.SourceSystemAuth))
+
+	re, err := regexp.Compile(SourceSystemAuthConfigRegex)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile source system regular expression: %w", err)
+	}
+
+	for _, auth := range cfg.SourceSystemAuth {
+		matches := re.FindAllStringSubmatch(auth, -1)
+		if len(matches) != 1 {
+			return nil, fmt.Errorf("invalid source system authentication uri: %s - multiple matches for individual system", auth)
+		}
+		// 0 = full string, 1 = app id, 2 = key type, 3 = key contents
+		if len(matches[0]) != 4 {
+			return nil, fmt.Errorf("incorrect source system authentication uri: %s - should match expression %s", auth, SourceSystemAuthConfigRegex)
+		}
+		uri := matches[0]
+
+		appID := uri[1]
+		keyType := uri[2]
+		keyMaterial := uri[3]
+
+		var signer crypto.Signer
+		if keyType == KeyTypePrivateKey {
+			signer, err = githubauth.NewPrivateKeySigner(keyMaterial)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create private key signer: %w", err)
+			}
+		} else if keyType == KeyTypeKMSID {
+			signer, err = newKMSSigner(ctx, keyMaterial)
+			if err != nil {
+				return nil, fmt.Errorf("failed to create kms signer: %w", err)
+			}
+		} else {
+			return nil, fmt.Errorf("invalid key type: %s", keyType)
+		}
+
+		ghAppCfg := source.GitHubAppConfig{
+			AppID:  appID,
+			Signer: signer,
+		}
+		appConfigs = append(appConfigs, &ghAppCfg)
+	}
+	return appConfigs, nil
+}
+
+func newKMSSigner(ctx context.Context, keyID string) (crypto.Signer, error) {
+	client, err := kms.NewKeyManagementClient(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to setup kms client: %w", err)
+	}
+	signer, err := gcpkms.NewSigner(ctx, client, keyID)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create kms signer: %w", err)
+	}
+	return signer, nil
 }

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -116,6 +116,8 @@ func createAppConfigs(ctx context.Context, cfg *Config) ([]*source.GitHubAppConf
 		keyType := uri[2]
 		keyMaterial := uri[3]
 
+		fmt.Printf("appID=%s keyType=%s keyMaterial=%s\n", appID, keyType, keyMaterial)
+
 		var signer crypto.Signer
 		if keyType == KeyTypePrivateKey {
 			signer, err = githubauth.NewPrivateKeySigner(keyMaterial)

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -116,8 +116,6 @@ func createAppConfigs(ctx context.Context, cfg *Config) ([]*source.GitHubAppConf
 		keyType := uri[2]
 		keyMaterial := uri[3]
 
-		fmt.Printf("appID=%s keyType=%s keyMaterial=%s\n", appID, keyType, keyMaterial)
-
 		var signer crypto.Signer
 		if keyType == KeyTypePrivateKey {
 			signer, err = githubauth.NewPrivateKeySigner(keyMaterial)
@@ -133,11 +131,10 @@ func createAppConfigs(ctx context.Context, cfg *Config) ([]*source.GitHubAppConf
 			return nil, fmt.Errorf("invalid key type: %s", keyType)
 		}
 
-		ghAppCfg := source.GitHubAppConfig{
+		appConfigs = append(appConfigs, &source.GitHubAppConfig{
 			AppID:  appID,
 			Signer: signer,
-		}
-		appConfigs = append(appConfigs, &ghAppCfg)
+		})
 	}
 	return appConfigs, nil
 }

--- a/pkg/server/runner_test.go
+++ b/pkg/server/runner_test.go
@@ -15,23 +15,75 @@
 package server
 
 import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
 	"testing"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+
+	"github.com/abcxyz/github-token-minter/pkg/server/source"
+	"github.com/abcxyz/pkg/githubauth"
 	"github.com/abcxyz/pkg/logging"
+	"github.com/abcxyz/pkg/testutil"
 )
+
+func exportPrivateKeyAsPemStr(privkey *rsa.PrivateKey) (string, error) {
+	privkeyBytes := x509.MarshalPKCS1PrivateKey(privkey)
+	privkeyPem := pem.EncodeToMemory(
+		&pem.Block{
+			Type:  "RSA PRIVATE KEY",
+			Bytes: privkeyBytes,
+		},
+	)
+	return string(privkeyPem), nil
+}
 
 func TestCreateAppConfigs(t *testing.T) {
 	t.Parallel()
 
 	ctx := logging.WithLogger(t.Context(), logging.TestLogger(t))
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pemKey, err := exportPrivateKeyAsPemStr(privateKey)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pkSigner, err := githubauth.NewPrivateKeySigner(pemKey)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	cases := []struct {
 		name               string
 		sourcesSystemAuths []string
+		want               []*source.GitHubAppConfig
+		expErr             bool
+		expErrMsg          string
 	}{
 		{
 			name:               "missing configurations",
 			sourcesSystemAuths: []string{},
+			want:               []*source.GitHubAppConfig{},
+			expErr:             true,
+			expErrMsg:          "",
+		},
+		{
+			name:               "single configurations - private key",
+			sourcesSystemAuths: []string{fmt.Sprintf(`gha://1234?private_key=%s`, pemKey)},
+			want: []*source.GitHubAppConfig{
+				{
+					AppID:  "1234",
+					Signer: pkSigner,
+				},
+			},
+			expErr:    false,
+			expErrMsg: "",
 		},
 	}
 
@@ -41,7 +93,17 @@ func TestCreateAppConfigs(t *testing.T) {
 
 			cfg := &Config{SourceSystemAuth: tc.sourcesSystemAuths}
 
-			createAppConfigs(ctx, cfg)
+			got, err := createAppConfigs(ctx, cfg)
+			if diff := cmp.Diff(tc.want, got, cmpopts.IgnoreFields(source.GitHubAppConfig{}, "Signer")); diff != "" {
+				t.Errorf("mismatch (-want, +got):\n%s", diff)
+			}
+
+			if msg := testutil.DiffErrString(err, tc.expErrMsg); msg != "" {
+				t.Fatal(msg)
+			}
+			if !tc.expErr && got == nil && tc.want != nil {
+				t.Errorf("result nil without error")
+			}
 		})
 	}
 }

--- a/pkg/server/runner_test.go
+++ b/pkg/server/runner_test.go
@@ -1,0 +1,47 @@
+// Copyright 2025 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package server
+
+import (
+	"testing"
+
+	"github.com/abcxyz/pkg/logging"
+)
+
+func TestCreateAppConfigs(t *testing.T) {
+	t.Parallel()
+
+	ctx := logging.WithLogger(t.Context(), logging.TestLogger(t))
+
+	cases := []struct {
+		name               string
+		sourcesSystemAuths []string
+	}{
+		{
+			name:               "missing configurations",
+			sourcesSystemAuths: []string{},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			cfg := &Config{SourceSystemAuth: tc.sourcesSystemAuths}
+
+			createAppConfigs(ctx, cfg)
+		})
+	}
+}

--- a/pkg/server/source/github.go
+++ b/pkg/server/source/github.go
@@ -26,16 +26,22 @@ import (
 	"github.com/abcxyz/pkg/githubauth"
 )
 
+// GitHubAppConfig is a struct that contains the identifier for a GitHub App
+// and a Signer that can be used to sign requests.
 type GitHubAppConfig struct {
 	AppID  string
 	Signer crypto.Signer
 }
 
+// gitHubSourceSystem is a SourceSystem implementation that is backed by GitHub.
 type gitHubSourceSystem struct {
 	apps    []*githubauth.App
 	baseURL string
 }
 
+// NewGitHubSourceSystem creates a representation of a GitHub system. This includes
+// information about what the base url and any of the Apps that can be used by the
+// system.
 func NewGitHubSourceSystem(ctx context.Context, configs []*GitHubAppConfig, systemURL string) (System, error) {
 	// Set the access token url pattern if it is provided.
 	var options []githubauth.Option

--- a/pkg/server/source/github.go
+++ b/pkg/server/source/github.go
@@ -1,0 +1,126 @@
+// Copyright 2025 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+import (
+	"context"
+	"crypto"
+	"errors"
+	"fmt"
+	"net/http"
+
+	"github.com/google/go-github/v64/github"
+
+	"github.com/abcxyz/pkg/githubauth"
+)
+
+type GitHubAppConfig struct {
+	AppID  string
+	Signer crypto.Signer
+}
+
+type gitHubSourceSystem struct {
+	apps    []*githubauth.App
+	baseURL string
+}
+
+func NewGitHubSourceSystem(ctx context.Context, configs []*GitHubAppConfig, systemURL string) (System, error) {
+	// Set the access token url pattern if it is provided.
+	var options []githubauth.Option
+	if systemURL != "" {
+		options = append(options, githubauth.WithBaseURL(systemURL))
+	}
+	apps := make([]*githubauth.App, len(configs))
+	for ix, cfg := range configs {
+		var err error
+		// Setup the GitHub App.
+		app, err := githubauth.NewApp(cfg.AppID, cfg.Signer, options...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create github app: %w", err)
+		}
+		apps[ix] = app
+	}
+	return &gitHubSourceSystem{apps, systemURL}, nil
+}
+
+// MintAccessToken implements SourceSystem.
+func (g *gitHubSourceSystem) MintAccessToken(ctx context.Context, org, repo string, repositories []string, permissions map[string]string) (string, error) {
+	var errs []error
+	var installation *githubauth.AppInstallation
+	var err error
+	for _, app := range g.apps {
+		installation, err = app.InstallationForRepo(ctx, org, repo)
+		if err != nil {
+			errs = append(errs, err)
+		}
+	}
+	if len(errs) != 0 {
+		return "", fmt.Errorf("errors retrieving GitHub installation: %w", errors.Join(errs...))
+	}
+	if repositories == nil {
+		allRepoRequest := &githubauth.TokenRequestAllRepos{Permissions: permissions}
+
+		accessToken, err := installation.AccessTokenAllRepos(ctx, allRepoRequest)
+		if err != nil {
+			return "", fmt.Errorf("error generating GitHub access token: %w", err)
+		}
+		return accessToken, nil
+	}
+	tokenRequest := githubauth.TokenRequest{
+		Repositories: repositories,
+		Permissions:  permissions,
+	}
+	accessToken, err := installation.AccessToken(ctx, &tokenRequest)
+	if err != nil {
+		return "", fmt.Errorf("error generating GitHub access token: %w", err)
+	}
+	return accessToken, nil
+}
+
+// RetrieveFileContents implements SourceSystem.
+func (g *gitHubSourceSystem) RetrieveFileContents(ctx context.Context, org, repo, filePath, ref string) ([]byte, error) {
+	token, err := g.MintAccessToken(ctx, org, repo, []string{repo}, map[string]string{"contents": "read"})
+	if err != nil {
+		return nil, fmt.Errorf("error minting access token for GitHub: %w", err)
+	}
+	client := github.NewClient(nil).WithAuthToken(token)
+	if g.baseURL != "" {
+		client, err = client.WithEnterpriseURLs(g.baseURL, g.baseURL)
+		if err != nil {
+			return nil, fmt.Errorf("error creating GitHub client: %w", err)
+		}
+	}
+	fileContents, _, resp, err := client.Repositories.GetContents(ctx, org, repo, filePath, &github.RepositoryContentGetOptions{Ref: ref})
+	if err != nil {
+		if resp.StatusCode == http.StatusNotFound {
+			return nil, nil
+		} else {
+			return nil, fmt.Errorf("error reading configuration file @ %s/%s/%s: %w", org, repo, filePath, err)
+		}
+	}
+	if fileContents != nil {
+		contents, err := fileContents.GetContent()
+		if err != nil {
+			return nil, fmt.Errorf("error reading configuration file contents @ %s/%s/%s: %w", org, repo, filePath, err)
+		}
+		return []byte(contents), nil
+	}
+	return nil, nil
+}
+
+// BaseURL implements SourceSystem.
+func (g *gitHubSourceSystem) BaseURL() string {
+	return "https://github.com"
+}

--- a/pkg/server/source/github.go
+++ b/pkg/server/source/github.go
@@ -64,6 +64,10 @@ func (g *gitHubSourceSystem) MintAccessToken(ctx context.Context, org, repo stri
 		installation, err = app.InstallationForRepo(ctx, org, repo)
 		if err != nil {
 			errs = append(errs, err)
+		} else {
+			// Accept the first installation that provides a token
+			// @TODO(bradegler) - resolve how to handle multiple GitHub apps
+			break
 		}
 	}
 	if len(errs) != 0 {

--- a/pkg/server/source/source_system.go
+++ b/pkg/server/source/source_system.go
@@ -1,0 +1,30 @@
+// Copyright 2025 The Authors (see AUTHORS file)
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package source
+
+import "context"
+
+type System interface {
+	// MintAccessToken generates a new access token on behalf of the org/rep for the given repositories with
+	// the specified permissions.
+	MintAccessToken(ctx context.Context, org, repo string, repositories []string, permissions map[string]string) (string, error)
+
+	// RetrieveFileContents gets the contents of the file at filePath with the specified ref
+	// from the org/repo.
+	RetrieveFileContents(ctx context.Context, org, repo, filePath, ref string) ([]byte, error)
+
+	// BaseURL gets the base url for the system.
+	BaseURL() string
+}

--- a/pkg/server/token_minter_test.go
+++ b/pkg/server/token_minter_test.go
@@ -26,6 +26,7 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"sort"
 	"strings"
 	"testing"
 	"time"
@@ -57,6 +58,7 @@ func handleAccessTokenRequest(w http.ResponseWriter, r *http.Request) {
 	for k, v := range request.Permissions {
 		perms = append(perms, fmt.Sprintf("%s=%s", k, v))
 	}
+	sort.Strings(perms)
 
 	w.WriteHeader(201)
 	fmt.Fprintf(w, `{"token": "%s"}`, perms)


### PR DESCRIPTION
* Moved the GitHub specific code behind an interface to make room for additional implementations (GitLab).
* Started a means to specify multiple GitHub Apps to be used. 
 
The multi App work is not completed as there are two things left to solve in a follow up PR that I wouldn't mind some feedback on. The current implementation just loops through them which is dumb.

* First, how to deal with configuration for multiple Apps. I'm not sure if I want multiple command line options as they would need to be pairs of APP_ID/PRIVATE_KEY so possibly some kind of config file is warranted? This needs to be thought through still.
* Second, how to determine which app to pick for any given request. I'm thinking this is probably tied to the request object but I'm still trying to figure out how to do this correctly.