### PR TITLE
fix: remove logging of key

### DIFF
--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -70,7 +70,12 @@ func (c *ServerCommand) Run(ctx context.Context, args []string) error {
 	if err := c.cfg.Validate(); err != nil {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
+
+	// Avoid logging the private key
+	saveKey := c.cfg.PrivateKey
+	c.cfg.PrivateKey = ""
 	logger.InfoContext(ctx, "loaded configuration", "config", c.cfg)
+	c.cfg.PrivateKey = saveKey
 
 	if err := server.Run(ctx, c.cfg); err != nil {
 		return fmt.Errorf("failed to start server: %w", err)


### PR DESCRIPTION
This is a short term fix to prevent the logging of the private key in a location that logs the configuration object.

Additional work to be done in https://github.com/abcxyz/github-token-minter/issues/201 to prevent this long term.