### PR TITLE
fix: minty config update for moving of create-tag action

### DIFF
--- a/.github/minty.yaml
+++ b/.github/minty.yaml
@@ -15,7 +15,7 @@ scope:
   create-tag:
     rule:
       if: |-
-        assertion.job_workflow_ref == "abcxyz/pkg/.github/workflows/create-tag.yml@refs/heads/main" &&
+        assertion.job_workflow_ref == "abcxyz/actions/.github/workflows/create-tag.yml@refs/heads/main" &&
         assertion.workflow_ref.startsWith("abcxyz/github-token-minter/.github/workflows/create-tag.yml") &&
         assertion.ref == 'refs/heads/main' &&
         assertion.event_name == 'workflow_dispatch'


### PR DESCRIPTION
Moving the `create-tag` action to the abcyxz/actions repo changes the job_workflow_ref to be the actions repo instead of pkg. This causes the create-tag reusable workflow to fail when trying to lookup the correct scope for minty when trying to authenticate.