### PR TITLE
feat: implement slog/LogValuer to redact private keys no matter where they are logged

### DIFF
--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -71,11 +71,7 @@ func (c *ServerCommand) Run(ctx context.Context, args []string) error {
 		return fmt.Errorf("invalid configuration: %w", err)
 	}
 
-	// Avoid logging the private key
-	saveKey := c.cfg.PrivateKey
-	c.cfg.PrivateKey = ""
 	logger.InfoContext(ctx, "loaded configuration", "config", c.cfg)
-	c.cfg.PrivateKey = saveKey
 
 	if err := server.Run(ctx, c.cfg); err != nil {
 		return fmt.Errorf("failed to start server: %w", err)


### PR DESCRIPTION
Fixes #201 

This will prevent accidental of logging of private keys if the config object gets logged.