### PR TITLE
chore: remove GITHUB_INSTALL_ID from the terraform module as it hasn't been needed since v2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,37 +26,14 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  # Linting jobs
-  terraform_lint:
-    uses: 'abcxyz/actions/.github/workflows/terraform-lint.yml@main' # ratchet:exclude
-    with:
-      directory: 'terraform'
-      terraform_version: '1.7.4'
-
-  go_lint:
-    uses: 'abcxyz/actions/.github/workflows/go-lint.yml@main' # ratchet:exclude
-
   go_test:
     uses: 'abcxyz/actions/.github/workflows/go-test.yml@main' # ratchet:exclude
-
-  yaml_lint:
-    uses: 'abcxyz/actions/.github/workflows/yaml-lint.yml@main' # ratchet:exclude
-
-  lint_and_unit:
-    runs-on: 'ubuntu-latest'
-    needs:
-      - 'go_lint'
-      - 'go_test'
-      - 'terraform_lint'
-      - 'yaml_lint'
-    steps:
-      - run: 'echo prechecks complete'
 
   # Build the main github-token-minter server and push to artifact registry
   build-github-token-minter-server:
     runs-on: 'ubuntu-latest'
     needs:
-      - 'lint_and_unit'
+      - 'go_test'
     permissions:
       contents: 'read'
       id-token: 'write'

--- a/pkg/config/config_evaluator_test.go
+++ b/pkg/config/config_evaluator_test.go
@@ -375,7 +375,7 @@ func TestOrderedConfigFileLoader(t *testing.T) {
 
 			got, _, err := tc.reader.Eval(ctx, tc.org, tc.repo, tc.scope, tc.token)
 			if diff := cmp.Diff(tc.want, got, cmp.FilterPath(func(p cmp.Path) bool {
-				return !(p.Last().String() == "Program")
+				return p.Last().String() != "Program"
 			}, cmp.Ignore())); diff != "" {
 				t.Errorf("mismatch (-want, +got):\n%s", diff)
 			}

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -117,17 +117,18 @@ func createAppConfigs(ctx context.Context, cfg *Config) ([]*source.GitHubAppConf
 		keyMaterial := uri[3]
 
 		var signer crypto.Signer
-		if keyType == KeyTypePrivateKey {
+		switch keyType {
+		case KeyTypePrivateKey:
 			signer, err = githubauth.NewPrivateKeySigner(keyMaterial)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create private key signer: %w", err)
 			}
-		} else if keyType == KeyTypeKMSID {
+		case KeyTypeKMSID:
 			signer, err = newKMSSigner(ctx, keyMaterial)
 			if err != nil {
 				return nil, fmt.Errorf("failed to create kms signer: %w", err)
 			}
-		} else {
+		default:
 			return nil, fmt.Errorf("invalid key type: %s", keyType)
 		}
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -57,7 +57,7 @@ module "cloud_run" {
   image                 = var.image
   ingress               = var.enable_gclb ? "internal-and-cloud-load-balancing" : "all"
   min_instances         = 1
-  secrets               = ["github-application-id", "github-installation-id", "github-privatekey"]
+  secrets               = ["github-application-id", "github-privatekey"]
   service_account_email = google_service_account.run_service_account.email
   service_iam = {
     admins     = var.service_iam.admins
@@ -70,10 +70,6 @@ module "cloud_run" {
   secret_envvars = {
     "GITHUB_APP_ID" : {
       name : "github-application-id",
-      version : "latest",
-    },
-    "GITHUB_INSTALL_ID" : {
-      name : "github-installation-id",
       version : "latest",
     },
     "GITHUB_PRIVATE_KEY" : {


### PR DESCRIPTION
This secret was a left over from earlier < 1.0 deployments where we targeted a specific installation. This secret is no longer used and doesn't need to be created.