### PR TITLE
feat: take the target org as a parameter on the request

### DIFF
--- a/pkg/config/config_loader_test.go
+++ b/pkg/config/config_loader_test.go
@@ -206,7 +206,7 @@ rule:
 	ctx := t.Context()
 	for _, tc := range cases {
 		mux := http.NewServeMux()
-		mux.Handle("GET /repos/test_org/test_repo/installation", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		mux.Handle("GET /orgs/test_org/installation", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			fmt.Fprintf(w, `{"access_tokens_url": "http://%s/app/installations/123/access_tokens"}`, r.Host)
 		}))
 		mux.Handle("POST /app/installations/123/access_tokens", http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/server/source/github.go
+++ b/pkg/server/source/github.go
@@ -68,7 +68,7 @@ func (g *gitHubSourceSystem) MintAccessToken(ctx context.Context, org, repo stri
 	var installation *githubauth.AppInstallation
 	var err error
 	for _, app := range g.apps {
-		installation, err = app.InstallationForRepo(ctx, org, repo)
+		installation, err = app.InstallationForOrg(ctx, org)
 		if err != nil {
 			errs = append(errs, err)
 		} else {

--- a/testdata/configs/org1/minty.yaml
+++ b/testdata/configs/org1/minty.yaml
@@ -1,0 +1,13 @@
+version: 'minty.abcxyz.dev/v2'
+rule:
+  if: true
+
+scope:
+  minty_cross_org:
+    rule:
+      if: 'assertion.workflow_ref.startsWith("abcxyz/pkg/.github/workflows/test.yml")'
+    repositories:
+      - 'repoA'
+      - 'repoB'
+    permissions:
+      contents: 'write'

--- a/testdata/configs/org1/repoA.yaml
+++ b/testdata/configs/org1/repoA.yaml
@@ -1,0 +1,12 @@
+version: 'minty.abcxyz.dev/v2'
+rule:
+  if: true
+
+scope:
+  cross_org_test:
+    rule:
+      if: 'assertion.workflow_ref.startsWith("abcxyz/pkg/.github/workflows/test.yml")'
+    repositories:
+      - 'repoA'
+    permissions:
+      issues: 'read'

--- a/testdata/configs/org1/repoB.yaml
+++ b/testdata/configs/org1/repoB.yaml
@@ -1,0 +1,12 @@
+version: 'minty.abcxyz.dev/v2'
+rule:
+  if: true
+
+scope:
+  cross_org_test:
+    rule:
+      if: 'assertion.workflow_ref.startsWith("abcxyz/pkg/.github/workflows/test.yml")'
+    repositories:
+      - 'repoB'
+    permissions:
+      issues: 'read'


### PR DESCRIPTION
This will default to the org in the OIDC claim.

Currently, requests use the parsed org name from the OIDC claim which is fine if you are only ever requesting permissions to act on your own org, but in the case of GitHub administration we need to be able to target an org (A) from a central repository in another org (B).