### PR TITLE
feat: add a flag to the terraform module to control WIF usage

### DIFF
--- a/terraform/github-wif.tf
+++ b/terraform/github-wif.tf
@@ -26,6 +26,8 @@ locals {
 }
 
 resource "google_iam_workload_identity_pool" "default" {
+  count = var.enable_wif ? 1 : 0
+
   project = var.project_id
 
   workload_identity_pool_id = var.name               # 32 characters
@@ -38,6 +40,8 @@ resource "google_iam_workload_identity_pool" "default" {
 }
 
 resource "google_iam_workload_identity_pool_provider" "default" {
+  count = var.enable_wif ? 1 : 0
+
   project = var.project_id
 
   workload_identity_pool_id          = google_iam_workload_identity_pool.default.workload_identity_pool_id
@@ -54,6 +58,8 @@ resource "google_iam_workload_identity_pool_provider" "default" {
 }
 
 resource "google_service_account" "wif_service_account" {
+  count = var.enable_wif ? 1 : 0
+
   project = var.project_id
 
   account_id   = "${var.name}-wif-sa" # 30 characters
@@ -61,6 +67,8 @@ resource "google_service_account" "wif_service_account" {
 }
 
 resource "google_service_account_iam_member" "default" {
+  count = var.enable_wif ? 1 : 0
+
   service_account_id = google_service_account.wif_service_account.id
   role               = "roles/iam.workloadIdentityUser"
   member             = "principalSet://iam.googleapis.com/${google_iam_workload_identity_pool.default.name}/*"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -39,7 +39,7 @@ resource "google_service_account" "run_service_account" {
 module "gclb" {
   count = var.enable_gclb ? 1 : 0
 
-  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/gclb_cloud_run_backend?ref=ebaccaa0c906e89813e3b0b71fc5fc6be9ef0cdb"
+  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/gclb_cloud_run_backend?ref=1467eaf0115f71613727212b0b51b3f99e699842"
 
   project_id = var.project_id
 
@@ -49,7 +49,7 @@ module "gclb" {
 }
 
 module "cloud_run" {
-  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=ebaccaa0c906e89813e3b0b71fc5fc6be9ef0cdb"
+  source = "git::https://github.com/abcxyz/terraform-modules.git//modules/cloud_run?ref=1467eaf0115f71613727212b0b51b3f99e699842"
 
   project_id = var.project_id
 
@@ -62,7 +62,7 @@ module "cloud_run" {
   service_iam = {
     admins     = var.service_iam.admins
     developers = toset(concat(var.service_iam.developers, [var.ci_service_account_member]))
-    invokers   = toset(concat(var.service_iam.invokers, [google_service_account.wif_service_account.member]))
+    invokers   = toset(concat(var.service_iam.invokers, var.enable_wif ? [google_service_account.wif_service_account[0].member] : []))
   }
 
   envvars = var.envvars
@@ -77,6 +77,9 @@ module "cloud_run" {
       version : "latest",
     }
   }
+
+  additional_service_annotations  = var.enable_wif ? {} : { "run.googleapis.com/invoker-iam-disabled" : true }
+  additional_revision_annotations = var.enable_wif ? {} : { "run.googleapis.com/invoker-iam-disabled" : true }
 }
 
 # allow the ci service account to act as the cloud run service account

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -100,3 +100,11 @@ variable "envvars" {
   default     = {}
   description = "Environment variables for the Cloud Run service (plain text)."
 }
+
+# Enable workload identity federation and authenticated access requirements for the
+# cloud run service.
+variable "enable_wif" {
+  description = "Enable the use of workload identity federation. By default this is true"
+  type        = bool
+  default     = true
+}


### PR DESCRIPTION
Not all deployments need the protections of workload identity federation and this will make for a smoother deployment model for those users.