### PR TITLE
fix: org level tokens no longer functioned without new * syntax

### DIFF
--- a/pkg/privatekey/config.go
+++ b/pkg/privatekey/config.go
@@ -57,7 +57,8 @@ func (cfg *Config) Validate() (vErr error) {
 	if cfg.ImportJobPrefix == "" {
 		vErr = errors.Join(vErr, fmt.Errorf("IMPORT_JOB_PREFIX is required"))
 	}
-	return
+
+	return vErr
 }
 
 // ToFlags binds the config to the [cli.FlagSet] and returns it.

--- a/pkg/server/token_minter.go
+++ b/pkg/server/token_minter.go
@@ -279,8 +279,8 @@ func buildRepositoryList(ctx context.Context, request *tokenRequest, claims *oid
 // isRequestAllRepos determines if a request is allowed to request
 // a token with permissions to all repositories.
 func isRequestAllRepos(allowed, requested []string) bool {
-	return len(allowed) == 1 && allowed[0] == "*" &&
-		len(requested) == 1 && requested[0] == "*"
+	return len(requested) == 0 && len(allowed) == 0 || (len(allowed) == 1 && allowed[0] == "*" &&
+		len(requested) == 1 && requested[0] == "*")
 }
 
 // validateRepositories checks the set of requested repositories against the allow list

--- a/pkg/server/token_minter_test.go
+++ b/pkg/server/token_minter_test.go
@@ -718,6 +718,42 @@ func TestIsRequestAllRepos(t *testing.T) {
 			request: []string{"test1"},
 			want:    false,
 		},
+		{
+			name:    "allow empty request list with empty allowed",
+			allow:   []string{},
+			request: []string{},
+			want:    true,
+		},
+		{
+			name:    "disallow empty request list with non-empty allowed",
+			allow:   []string{"test1"},
+			request: []string{},
+			want:    false,
+		},
+		{
+			name:    "disallow non-empty request list with empty allowed",
+			allow:   []string{},
+			request: []string{"test1"},
+			want:    false,
+		},
+		{
+			name:    "disallow non-empty request list with empty allowed",
+			allow:   []string{},
+			request: []string{"test1"},
+			want:    false,
+		},
+		{
+			name:    "request for specific repo not in allowed list",
+			allow:   []string{"test2"},
+			request: []string{"test1"},
+			want:    false,
+		},
+		{
+			name:    "request for specific repo in allowed list",
+			allow:   []string{"test1"},
+			request: []string{"test1"},
+			want:    false,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION
Adding * to request/allowed access list caused empty [] comparison to no longer be treated as an action that worked on org level resources