### PR TITLE
chore: minor cleanup of inconsistencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ This command starts the GitHub Token Minter server.
 | `--org-config-path` | `ORG_CONFIG_PATH` | The path to the minty configuration file for an organization. |
 | `--org-config-repo` | `ORG_CONFIG_REPO` | The repository that contains the configuration file for an organization. |
 | `--ref` | `REF` | The ref (sha, branch, etc.) to look for configuration files at. |
-| `--config-cache-minutes` | `CONFIG_CACHE_MINUTES` | The number of minutes to cache configuration files before retrieving fresh ones. Defaults to 15 minutes. |
+| `--config-cache-seconds` | `CONFIG_CACHE_SECONDS` | The number of seconds to cache configuration files before retrieving fresh ones. Defaults to 900 seconds. |
 | `--jwks-cache-duration` | `JWKS_CACHE_DURATION` | The duration for which to cache the JWKS for an OIDC token issuer. |
 | `--issuer-allowlist` | `ISSUER_ALLOWLIST` | The list of OIDC token issuers that GitHub Token Minter will accept. Format is a comma-separated list of URLs or the flag can be specified multiple times. |
 | `--github-request-max-retries` | `GITHUB_REQUEST_MAX_RETRIES` | The maximum number of retries for GitHub API requests. Defaults to 3. |
@@ -146,14 +146,14 @@ This command mints a token.
 |---|---|---|
 | `--request` | `REQUEST` | The token request to mint a token for. |
 | `--token` | `TOKEN` | The OIDC token to exchange. This could be a GCP service account or GitHub token. |
-| `--mintyURL` | `MINTY_URL` | The URL of the minty server. |
+| `--minty-url` | `MINTY_URL` | The URL of the minty server. |
 
 Usage:
 
 ```bash
 minty tools mint \
   --token=$(gcloud auth print-identity-token --impersonate-service-account=my_service_account@iam.gserviceaccount.com --audiences='https://<token minter cloud run service url>' --include-email) \
-  --mintyURL=https://minty.url
+  --minty-url=https://minty.url
   --request='{"scope": "read-issues", "org_name": "some-org", "repositories": ["some-repo"], "permissions": {"issues": "read"}}'
 ```
 

--- a/pkg/cli/server.go
+++ b/pkg/cli/server.go
@@ -35,13 +35,13 @@ type ServerCommand struct {
 }
 
 func (c *ServerCommand) Desc() string {
-	return ``
+	return `Start the GitHub Token Minter server.`
 }
 
 func (c *ServerCommand) Help() string {
 	return `
 Usage: {{ COMMAND }} [options]
-       Execute the minty configuration validator 
+       Start the GitHub Token Minter server.
 `
 }
 

--- a/pkg/config/config_loader.go
+++ b/pkg/config/config_loader.go
@@ -185,15 +185,32 @@ func (l *fixedRepoConfigFileLoader) Source(org, repo string) string {
 }
 
 func Read(contents []byte) (*Config, error) {
-	var config Config
-	// default to the latest version of the config format
-	if err := yaml.Unmarshal(contents, &config); err != nil {
-		// attempt to unmarshal in the old format
-		var cv1 v1Document
-		if err := yaml.Unmarshal(contents, &cv1); err != nil {
-			return nil, fmt.Errorf("error parsing yaml document: %w", err)
-		}
-		config = NewConfigFromV1(cv1)
+	type probe struct {
+		Version string         `yaml:"version"`
+		Scope   map[string]any `yaml:"scope"`
 	}
-	return &config, nil
+	var p probe
+
+	// If it's a YAML array (V1), Unmarshal into a struct will fail.
+	err := yaml.Unmarshal(contents, &p)
+
+	if err == nil {
+		// It's a YAML object.
+		if p.Version == configVersionV2 || (p.Version == "" && len(p.Scope) > 0) {
+			var config Config
+			if err := yaml.Unmarshal(contents, &config); err != nil {
+				return nil, fmt.Errorf("error parsing v2 config: %w", err)
+			}
+			return &config, nil
+		}
+	}
+
+	// Try V1 (array)
+	var cv1 v1Document
+	if err := yaml.Unmarshal(contents, &cv1); err == nil {
+		config := NewConfigFromV1(cv1)
+		return &config, nil
+	}
+
+	return nil, fmt.Errorf("failed to parse config as v1 or v2")
 }

--- a/pkg/minter/config.go
+++ b/pkg/minter/config.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Config defines the set of environment variables required
-// for running the artifact job.
+// for minting tokens.
 type Config struct {
 	Request  string
 	Token    string
@@ -62,7 +62,7 @@ func (cfg *Config) ToFlags(set *cli.FlagSet) *cli.FlagSet {
 	})
 
 	f.StringVar(&cli.StringVar{
-		Name:   "mintyURL",
+		Name:   "minty-url",
 		Target: &cfg.MintyURL,
 		EnvVar: "MINTY_URL",
 		Usage:  `The URL of the minty server.`,

--- a/pkg/mintycfg/config.go
+++ b/pkg/mintycfg/config.go
@@ -21,7 +21,7 @@ import (
 )
 
 // Config defines the set of environment variables required
-// for running the artifact job.
+// for running the minty configuration validator.
 type Config struct {
 	MintyFile string
 	Scope     string
@@ -57,7 +57,7 @@ func (cfg *Config) ToFlags(set *cli.FlagSet) *cli.FlagSet {
 	f.StringVar(&cli.StringVar{
 		Name:   "token",
 		Target: &cfg.Token,
-		EnvVar: "token",
+		EnvVar: "TOKEN",
 		Usage:  `The token to test with.`,
 	})
 

--- a/pkg/server/claims.go
+++ b/pkg/server/claims.go
@@ -17,6 +17,7 @@ package server
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/http"
 	"strings"
 
@@ -100,6 +101,16 @@ func (c *oidcClaims) asMap() map[string]interface{} {
 		"enterprise":          c.EnterpriseName,
 		"enterprise_id":       c.EnterpriseID,
 	}
+}
+
+// LogValue implements slog.LogValuer to redact sensitive data.
+func (c *oidcClaims) LogValue() slog.Value {
+	type loggableClaims oidcClaims
+	lc := loggableClaims(*c)
+	if lc.Email != "" {
+		lc.Email = "[REDACTED]"
+	}
+	return slog.AnyValue(lc)
 }
 
 // ParseAuthToken converts a JWT token into a collection of OIDC claims.

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -92,6 +92,8 @@ const (
 	SourceSystemAuthConfigRegex = `gha\:\/\/(\d+)\?(private_key|kms_id)=([\s\S]*)`
 )
 
+var sourceSystemAuthRegexp = regexp.MustCompile(SourceSystemAuthConfigRegex)
+
 // Validate validates the artifacts config after load.
 func (cfg *Config) Validate() error {
 	if cfg.ConfigCacheSeconds == "" {
@@ -123,10 +125,6 @@ func (cfg *Config) Validate() error {
 		return fmt.Errorf("SOURCE_SYSTEM_AUTH is required")
 	}
 
-	re, err := regexp.Compile(SourceSystemAuthConfigRegex)
-	if err != nil {
-		return fmt.Errorf("failed to compile source system regular expression: %w", err)
-	}
 	if len(cfg.SourceSystemAuth) != 1 {
 		// Limit this to a single source system for now.
 		// @TODO(bradegler) - remove this constraint in the future when it is understood how to target
@@ -135,7 +133,7 @@ func (cfg *Config) Validate() error {
 	}
 
 	for _, auth := range cfg.SourceSystemAuth {
-		if !re.MatchString(auth) {
+		if !sourceSystemAuthRegexp.MatchString(auth) {
 			return fmt.Errorf("incorrect source system authentication uri: %s - should match expression %s", auth, SourceSystemAuthConfigRegex)
 		}
 	}
@@ -220,10 +218,10 @@ func (cfg *Config) ToFlags(set *cli.FlagSet) *cli.FlagSet {
 	})
 
 	f.StringVar(&cli.StringVar{
-		Name:   "config-cache-minutes",
+		Name:   "config-cache-seconds",
 		Target: &cfg.ConfigCacheSeconds,
-		EnvVar: "CONFIG_CACHE_MINUTES",
-		Usage:  `The number of minutes to cache configuration files before retrieving fresh ones. Defaults to 15 minutes.`,
+		EnvVar: "CONFIG_CACHE_SECONDS",
+		Usage:  `The number of seconds to cache configuration files before retrieving fresh ones. Defaults to 900 seconds.`,
 	})
 
 	f.DurationVar(&cli.DurationVar{

--- a/pkg/server/jwk_resolver.go
+++ b/pkg/server/jwk_resolver.go
@@ -36,6 +36,7 @@ type JWKResolver interface {
 type OIDCResolver struct {
 	issuerAllowlist []string
 	cache           *cache.Cache[jwk.Set]
+	httpClient      *http.Client
 }
 
 type OpenIDConfiguration struct {
@@ -47,6 +48,9 @@ func NewOIDCResolver(ctx context.Context, issuerAllowlist []string, cacheTimeout
 	return &OIDCResolver{
 		issuerAllowlist: issuerAllowlist,
 		cache:           cache.New[jwk.Set](cacheTimeout),
+		httpClient: &http.Client{
+			Timeout: 10 * time.Second,
+		},
 	}
 }
 
@@ -91,7 +95,7 @@ func (r *OIDCResolver) resolveJwksURI(ctx context.Context, issuer string) (strin
 	if err != nil {
 		return "", fmt.Errorf("error creating GET request for %q: %w", configURL, err)
 	}
-	resp, err := http.DefaultClient.Do(req)
+	resp, err := r.httpClient.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("error fetching OpenID Configuration from %q: %w", configURL, err)
 	}

--- a/pkg/server/runner.go
+++ b/pkg/server/runner.go
@@ -18,7 +18,6 @@ import (
 	"context"
 	"crypto"
 	"fmt"
-	"regexp"
 	"strconv"
 	"time"
 
@@ -105,13 +104,8 @@ func Run(ctx context.Context, cfg *Config) error {
 func createAppConfigs(ctx context.Context, cfg *Config) ([]*source.GitHubAppConfig, error) {
 	appConfigs := make([]*source.GitHubAppConfig, 0, len(cfg.SourceSystemAuth))
 
-	re, err := regexp.Compile(SourceSystemAuthConfigRegex)
-	if err != nil {
-		return nil, fmt.Errorf("failed to compile source system regular expression: %w", err)
-	}
-
 	for _, auth := range cfg.SourceSystemAuth {
-		matches := re.FindAllStringSubmatch(auth, -1)
+		matches := sourceSystemAuthRegexp.FindAllStringSubmatch(auth, -1)
 		if len(matches) != 1 {
 			return nil, fmt.Errorf("invalid source system authentication uri: %s - multiple matches for individual system", auth)
 		}
@@ -126,6 +120,7 @@ func createAppConfigs(ctx context.Context, cfg *Config) ([]*source.GitHubAppConf
 		keyMaterial := uri[3]
 
 		var signer crypto.Signer
+		var err error
 		switch keyType {
 		case KeyTypePrivateKey:
 			signer, err = githubauth.NewPrivateKeySigner(keyMaterial)

--- a/pkg/server/token_minter.go
+++ b/pkg/server/token_minter.go
@@ -23,7 +23,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"html"
 	"io"
 	"net/http"
 	"strings"
@@ -94,7 +93,11 @@ func (s *TokenMinterServer) handleToken() http.Handler {
 		}
 
 		w.WriteHeader(resp.Code)
-		fmt.Fprint(w, html.EscapeString(resp.Message))
+		_, err := w.Write([]byte(resp.Message))
+		if err != nil {
+			logger.ErrorContext(ctx, "error writing response",
+				"error", err)
+		}
 	})
 }
 


### PR DESCRIPTION
## Summary
This PR addresses several code quality, style, and functional issues identified during a thorough code review. It includes bug fixes for configuration unit mismatches, security improvements regarding PII logging and token handling, and general cleanup for consistency and performance.
## Key Changes
### Bug Fixes & Functional Improvements
- **Fixed Cache Unit Mismatch**: Renamed flag `--config-cache-minutes` to `--config-cache-seconds` (and environment variable to `CONFIG_CACHE_SECONDS`) in `pkg/server/config.go` and `README.md` to align with the code treating the value as seconds.
- **Robust Config Version Detection**: Updated `Read` in `pkg/config/config_loader.go` to use a probe struct to check the `version` field before full unmarshaling, preventing masking of parsing errors.
- **Token Output Fix**: Removed HTML escaping of the token response in `pkg/server/token_minter.go` to prevent token corruption, and added proper error handling for response writing.
### Security & Robustness
- **Redacted PII in Logs**: Implemented `slog.LogValuer` on `oidcClaims` in `pkg/server/claims.go` to automatically redact the `email` field when logging claims.
- **Added HTTP Client Timeout**: Replaced `http.DefaultClient` with a custom client containing a 10-second timeout in `pkg/server/jwk_resolver.go` to prevent hanging requests.
### Style & Polish
- **Standardized Naming**: Renamed flag `mintyURL` to `minty-url` in `pkg/minter/config.go` and `README.md`, and env var `token` to `TOKEN` in `pkg/mintycfg/config.go`.
- **CLI Help Text**: Corrected the description and help text in `pkg/cli/server.go` to accurately describe the server command instead of a validator.
- **Cleaned Up Comments**: Fixed copypasta in comments referring to "artifact job" in `pkg/mintycfg` and `pkg/minter`.
- **Regex Optimization**: Moved `SourceSystemAuthConfigRegex` compilation to the package level in `pkg/server/config.go` to avoid redundant compilation.
- **Unused Imports**: Removed unused imports (`regexp` in `runner.go` and `html` in `token_minter.go`).