### PR TITLE
chore: update nodejs to 24

### DIFF
--- a/.github/actions/minty/action.yml
+++ b/.github/actions/minty/action.yml
@@ -17,6 +17,6 @@ outputs:
     description: 'Newly minted token'
 
 runs:
-  using: 'node20'
+  using: 'node24'
   main: 'dist/main/index.js'
   post: 'dist/post/index.js'


### PR DESCRIPTION
GitHub is deprecating Nodejs 20 in GitHub Actions Runners(https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/). Update minty from `node20` to `node24`.

In `import-settings` workflow of `google-gh-automation/google-infra-github`, we tried to force to use Nodejs 24(see [here](https://github.com/google-gh-automation/google-infra-github/blob/main/.github/workflows/import-settings.yml#L34)). And minty is working well. So I assume there is no compatibility issues.